### PR TITLE
✨ Feature: #80 콘서트 셋리스트 및 가사 관련 API 구현

### DIFF
--- a/src/v2/app.module.ts
+++ b/src/v2/app.module.ts
@@ -4,6 +4,7 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ConcertModule } from 'src/v2/concert/concert.module';
 import { GlobalResponseInterceptor } from './common/interceptors/global-response.interceptor';
 import { SetlistModule } from './setlist/setlist.module';
+import { SongModule } from './song/song.module';
 
 @Module({
   imports: [
@@ -12,6 +13,7 @@ import { SetlistModule } from './setlist/setlist.module';
     }),
     ConcertModule,
     SetlistModule,
+    SongModule,
   ],
   controllers: [],
   providers: [

--- a/src/v2/app.module.ts
+++ b/src/v2/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 import { ConcertModule } from 'src/v2/concert/concert.module';
 import { GlobalResponseInterceptor } from './common/interceptors/global-response.interceptor';
+import { SetlistModule } from './setlist/setlist.module';
 
 @Module({
   imports: [
@@ -10,6 +11,7 @@ import { GlobalResponseInterceptor } from './common/interceptors/global-response
       isGlobal: true,
     }),
     ConcertModule,
+    SetlistModule,
   ],
   controllers: [],
   providers: [

--- a/src/v2/concert/concert.controller.ts
+++ b/src/v2/concert/concert.controller.ts
@@ -134,4 +134,20 @@ export class ConcertController {
   getConcertSetlists(@Param('id', ParsePositiveIntPipe) id: number) {
     return this.concertService.getConcertSetlists(id);
   }
+
+  // 콘서트의 대표 셋리스트 조회
+  @Get(':id/main-setlist')
+  @ApiOperation({
+    summary: '특정 콘서트 대표 셋리스트 조회',
+    description: '특정 콘서트에 해당하는 대표 셋리스트를 조회합니다.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: '콘서트의 ID',
+    type: Number,
+    example: 1,
+  })
+  getConcertMainSetlist(@Param('id', ParsePositiveIntPipe) id: number) {
+    return this.concertService.getConcertMainSetlist(id);
+  }
 }

--- a/src/v2/concert/concert.controller.ts
+++ b/src/v2/concert/concert.controller.ts
@@ -150,4 +150,29 @@ export class ConcertController {
   getConcertMainSetlist(@Param('id', ParsePositiveIntPipe) id: number) {
     return this.concertService.getConcertMainSetlist(id);
   }
+
+  // 콘서트의 셋리스트 상세 조회
+  @Get(':concertId/setlists/:setlistId')
+  @ApiOperation({
+    summary: '특정 콘서트 셋리스트 상세 조회',
+    description: '특정 콘서트의 셋리스트를 상세 조회합니다.',
+  })
+  @ApiParam({
+    name: 'concertId',
+    description: '콘서트의 ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiParam({
+    name: 'setlistId',
+    description: '셋리스트의 ID',
+    type: Number,
+    example: 1,
+  })
+  getSetlistDetails(
+    @Param('concertId', ParsePositiveIntPipe) concertId: number,
+    @Param('setlistId', ParsePositiveIntPipe) setlistId: number,
+  ) {
+    return this.concertService.getSetlistDetails(setlistId, concertId);
+  }
 }

--- a/src/v2/concert/concert.service.ts
+++ b/src/v2/concert/concert.service.ts
@@ -316,4 +316,64 @@ export class ConcertService {
       recentSetlist.type,
     );
   }
+
+  // 콘서트의 셋리스트 상세 조회
+  async getSetlistDetails(setlistId: number, concertId: number) {
+    // 콘서트 ID가 유효한지 확인
+    const concert = await this.prismaService.concert.findUnique({
+      where: { id: concertId },
+    });
+
+    if (!concert) {
+      throw new NotFoundException('해당 콘서트가 존재하지 않습니다.');
+    }
+
+    // 셋리스트 ID가 유효한지 확인
+    const setlist = await this.prismaService.setlist.findUnique({
+      where: { id: setlistId },
+    });
+    if (!setlist) {
+      throw new NotFoundException('해당 셋리스트가 존재하지 않습니다.');
+    }
+
+    // 콘서트 ID와 셋리스트 ID가 일치하는 콘서트셋리스트 확인
+    const concertSetlist = await this.prismaService.concertSetlist.findFirst({
+      where: {
+        setlistId: setlistId,
+        concertId: concertId,
+      },
+    });
+
+    // 콘서트셋리스트가 없을 경우 예외 처리
+    if (!concertSetlist) {
+      throw new NotFoundException(
+        '해당 셋리스트와 콘서트의 조합이 존재하지 않습니다.',
+      );
+    }
+    // 해당 콘서트의 모든 셋리스트 중 가장 startDate가 최신인 것 찾기
+    const latestSetlist = await this.prismaService.concertSetlist.findFirst({
+      where: {
+        concertId,
+      },
+      orderBy: {
+        setlist: {
+          startDate: 'desc',
+        },
+      },
+      include: {
+        setlist: true,
+      },
+    });
+
+    // status 가공
+    let status: string | null = null;
+
+    if (concertSetlist.type === 'EXPECTED') {
+      status = '예상';
+    } else if (setlist.id === latestSetlist?.setlist?.id) {
+      status = '최신';
+    }
+
+    return new SetlistResponseDto(setlist, status, concertSetlist.type);
+  }
 }

--- a/src/v2/concert/dto/setlist-response.dto.ts
+++ b/src/v2/concert/dto/setlist-response.dto.ts
@@ -8,15 +8,19 @@ export class SetlistResponseDto {
   imgUrl: string;
   status: string;
   type: SetlistType;
+  venue: string;
+  artist: string;
 
   constructor(setlist: Setlist, status: string | null = null, type: string) {
     this.id = setlist.id;
     this.title = setlist.title;
     this.imgUrl = setlist.imgUrl;
-    this.type = type as SetlistType; // 타입을 SetlistType으로 변환
+    this.type = type as SetlistType;
     this.title = setlist.title;
     this.startDate = setlist.startDate;
     this.endDate = setlist.endDate;
     this.status = status;
+    this.venue = setlist.venue;
+    this.artist = setlist.artist;
   }
 }

--- a/src/v2/setlist/dto/fanchant-response.dto.ts
+++ b/src/v2/setlist/dto/fanchant-response.dto.ts
@@ -10,8 +10,10 @@ export class FanchantResponseDto {
     this.id = setlistSong.id;
     this.setlistId = setlistSong.setlistId;
     this.songId = setlistSong.songId;
-    this.fanchant = setlistSong.fanchant
-      ? setlistSong.fanchant.split(/\r?\n/)
-      : [];
+    const rawFanchant = setlistSong.fanchant ?? '';
+    this.fanchant = rawFanchant
+      .split(/\r?\n/) // 줄바꿈 기준 분할
+      .map((line) => line.trim()) // 앞뒤 공백 제거
+      .filter(Boolean); // 빈 줄 제거
   }
 }

--- a/src/v2/setlist/dto/fanchant-response.dto.ts
+++ b/src/v2/setlist/dto/fanchant-response.dto.ts
@@ -1,0 +1,17 @@
+import { SetlistSong } from '@prisma/client';
+
+export class FanchantResponseDto {
+  id: number;
+  setlistId: number;
+  songId: number;
+  fanchant: string[];
+
+  constructor(setlistSong: SetlistSong) {
+    this.id = setlistSong.id;
+    this.setlistId = setlistSong.setlistId;
+    this.songId = setlistSong.songId;
+    this.fanchant = setlistSong.fanchant
+      ? setlistSong.fanchant.split(/\r?\n/)
+      : [];
+  }
+}

--- a/src/v2/setlist/dto/song-response.dto.ts
+++ b/src/v2/setlist/dto/song-response.dto.ts
@@ -1,0 +1,15 @@
+import { Song } from '@prisma/client';
+
+export class SongResponseDto {
+  id: number;
+  title: string;
+  artist: string;
+  orderIndex: number;
+
+  constructor(song: Song, orderIndex: number) {
+    this.id = song.id;
+    this.title = song.title;
+    this.artist = song.artist;
+    this.orderIndex = orderIndex;
+  }
+}

--- a/src/v2/setlist/setlist.controller.spec.ts
+++ b/src/v2/setlist/setlist.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SetlistController } from './setlist.controller';
+
+describe('SetlistController', () => {
+  let controller: SetlistController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SetlistController],
+    }).compile();
+
+    controller = module.get<SetlistController>(SetlistController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/v2/setlist/setlist.controller.ts
+++ b/src/v2/setlist/setlist.controller.ts
@@ -23,4 +23,29 @@ export class SetlistController {
   getSetlistSongs(@Param('id', ParsePositiveIntPipe) id: number) {
     return this.setlistService.getSetlistSongs(id);
   }
+
+  //노래 응원법 조회
+  @Get(':setlistId/songs/:songId/fanchant')
+  @ApiOperation({
+    summary: '특정 셋리스트의 곡 응원법 조회',
+    description: '특정 셋리스트의 곡에 대한 응원법을 조회합니다.',
+  })
+  @ApiParam({
+    name: 'setlistId',
+    description: '셋리스트의 ID',
+    type: Number,
+    example: 1,
+  })
+  @ApiParam({
+    name: 'songId',
+    description: '곡의 ID',
+    type: Number,
+    example: 1,
+  })
+  getSongFanchant(
+    @Param('setlistId', ParsePositiveIntPipe) setlistId: number,
+    @Param('songId', ParsePositiveIntPipe) songId: number,
+  ) {
+    return this.setlistService.getSongFanchant(setlistId, songId);
+  }
 }

--- a/src/v2/setlist/setlist.controller.ts
+++ b/src/v2/setlist/setlist.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ParsePositiveIntPipe } from '../common/pipes/parse-positive-int.pipe';
+import { SetlistService } from './setlist.service';
+
+@ApiTags('셋리스트')
+@Controller('setlist')
+export class SetlistController {
+  constructor(private readonly setlistService: SetlistService) {}
+
+  //셋리스트 노래 목록 조회
+  @Get('api/v2/setlists/:id/songs')
+  @ApiOperation({
+    summary: '특정 셋리스트의 곡 목록 조회',
+    description: '특정 셋리스트의 곡 목록을 조회합니다.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: '셋리스트의 ID',
+    type: Number,
+    example: 1,
+  })
+  getSetlistSongs(@Param('id', ParsePositiveIntPipe) id: number) {
+    return this.setlistService.getSetlistSongs(id);
+  }
+}

--- a/src/v2/setlist/setlist.controller.ts
+++ b/src/v2/setlist/setlist.controller.ts
@@ -4,12 +4,12 @@ import { ParsePositiveIntPipe } from '../common/pipes/parse-positive-int.pipe';
 import { SetlistService } from './setlist.service';
 
 @ApiTags('셋리스트')
-@Controller('setlist')
+@Controller('api/v2/setlist/')
 export class SetlistController {
   constructor(private readonly setlistService: SetlistService) {}
 
   //셋리스트 노래 목록 조회
-  @Get('api/v2/setlists/:id/songs')
+  @Get(':id/songs')
   @ApiOperation({
     summary: '특정 셋리스트의 곡 목록 조회',
     description: '특정 셋리스트의 곡 목록을 조회합니다.',

--- a/src/v2/setlist/setlist.controller.ts
+++ b/src/v2/setlist/setlist.controller.ts
@@ -4,7 +4,7 @@ import { ParsePositiveIntPipe } from '../common/pipes/parse-positive-int.pipe';
 import { SetlistService } from './setlist.service';
 
 @ApiTags('셋리스트')
-@Controller('api/v2/setlist/')
+@Controller('api/v2/setlists/')
 export class SetlistController {
   constructor(private readonly setlistService: SetlistService) {}
 

--- a/src/v2/setlist/setlist.module.ts
+++ b/src/v2/setlist/setlist.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SetlistController } from './setlist.controller';
+import { SetlistService } from './setlist.service';
+import { PrismaService } from 'prisma/prisma.service';
+
+@Module({
+  controllers: [SetlistController],
+  providers: [SetlistService, PrismaService],
+})
+export class SetlistModule {}

--- a/src/v2/setlist/setlist.service.spec.ts
+++ b/src/v2/setlist/setlist.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SetlistService } from './setlist.service';
+
+describe('SetlistService', () => {
+  let service: SetlistService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SetlistService],
+    }).compile();
+
+    service = module.get<SetlistService>(SetlistService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/v2/setlist/setlist.service.ts
+++ b/src/v2/setlist/setlist.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from 'prisma/prisma.service';
 import { SongResponseDto } from './dto/song-response.dto';
+import { FanchantResponseDto } from './dto/fanchant-response.dto';
 
 @Injectable()
 export class SetlistService {
@@ -28,5 +29,40 @@ export class SetlistService {
       (setlistSong) =>
         new SongResponseDto(setlistSong.song, setlistSong.orderIndex),
     );
+  }
+
+  // 곡 응원법 조회
+  async getSongFanchant(setlistId: number, songId: number) {
+    // 셋리스트 ID가 유효한지 확인
+    const setlist = await this.prismaService.setlist.findUnique({
+      where: { id: setlistId },
+    });
+    if (!setlist) {
+      throw new NotFoundException('해당 셋리스트가 존재하지 않습니다.');
+    }
+
+    // 곡 ID가 유효한지 확인
+    const song = await this.prismaService.song.findUnique({
+      where: { id: songId },
+    });
+    if (!song) {
+      throw new NotFoundException('해당 곡이 존재하지 않습니다.');
+    }
+
+    // 응원법 조회
+    const fanchant = await this.prismaService.setlistSong.findFirst({
+      where: {
+        setlistId,
+        songId,
+      },
+    });
+
+    if (!fanchant) {
+      throw new NotFoundException(
+        '해당 셋리스트와 곡의 조합이 존재하지 않습니다.',
+      );
+    }
+
+    return new FanchantResponseDto(fanchant);
   }
 }

--- a/src/v2/setlist/setlist.service.ts
+++ b/src/v2/setlist/setlist.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from 'prisma/prisma.service';
+import { SongResponseDto } from './dto/song-response.dto';
+
+@Injectable()
+export class SetlistService {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async getSetlistSongs(id: number) {
+    // 셋리스트 ID가 유효한지 확인
+    const setlist = await this.prismaService.setlist.findUnique({
+      where: { id },
+    });
+    if (!setlist) {
+      throw new NotFoundException('해당 셋리스트가 존재하지 않습니다.');
+    }
+
+    // 셋리스트에 해당하는 곡 목록 조회
+    const setlistSongs = await this.prismaService.setlistSong.findMany({
+      where: { setlistId: id },
+      include: {
+        song: true, // 곡 정보 포함
+      },
+      orderBy: { orderIndex: 'asc' },
+    });
+
+    return setlistSongs.map(
+      (setlistSong) =>
+        new SongResponseDto(setlistSong.song, setlistSong.orderIndex),
+    );
+  }
+}

--- a/src/v2/song/dto/lyrics-response.dto.ts
+++ b/src/v2/song/dto/lyrics-response.dto.ts
@@ -1,0 +1,37 @@
+import { Song } from '@prisma/client';
+
+export class LyricsResponseDto {
+  id: number;
+  title: string;
+  artist: string;
+  lyrics: string[];
+  pronunciation: string[];
+  translation: string[];
+  youtubeId: string;
+
+  constructor(song: Song) {
+    this.id = song.id;
+    this.title = song.title;
+    this.artist = song.artist;
+    this.lyrics = song.lyrics
+      ? song.lyrics
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean)
+      : [];
+
+    this.pronunciation = song.pronunciation
+      ? song.pronunciation
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean)
+      : [];
+    this.translation = song.translation
+      ? song.translation
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean)
+      : [];
+    this.youtubeId = song.youtubeId;
+  }
+}

--- a/src/v2/song/song.controller.spec.ts
+++ b/src/v2/song/song.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SongController } from './song.controller';
+
+describe('SongController', () => {
+  let controller: SongController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SongController],
+    }).compile();
+
+    controller = module.get<SongController>(SongController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/v2/song/song.controller.ts
+++ b/src/v2/song/song.controller.ts
@@ -1,7 +1,8 @@
 import { Controller, Get, Param } from '@nestjs/common';
 import { SongService } from './song.service';
-import { ApiOperation, ApiParam } from '@nestjs/swagger';
+import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
 
+@ApiTags('노래')
 @Controller('api/v2/songs')
 export class SongController {
   //특정 노래 가사 정보 조회

--- a/src/v2/song/song.controller.ts
+++ b/src/v2/song/song.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { SongService } from './song.service';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
+
+@Controller('api/v2/songs')
+export class SongController {
+  //특정 노래 가사 정보 조회
+  constructor(private readonly songService: SongService) {}
+  @Get(':id')
+  @ApiOperation({
+    summary: '특정 노래의 가사 정보 조회',
+    description: '특정 노래의 가사, 발음, 번역 정보를 조회합니다.',
+  })
+  @ApiParam({
+    name: 'id',
+    description: '노래의 ID',
+    type: Number,
+    example: '1',
+  })
+  async getSongLyrics(@Param('id') id: number) {
+    return this.songService.getSongLyrics(id);
+  }
+}

--- a/src/v2/song/song.module.ts
+++ b/src/v2/song/song.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SongController } from './song.controller';
+import { SongService } from './song.service';
+import { PrismaService } from 'prisma/prisma.service';
+
+@Module({
+  controllers: [SongController],
+  providers: [SongService, PrismaService],
+})
+export class SongModule {}

--- a/src/v2/song/song.service.spec.ts
+++ b/src/v2/song/song.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SongService } from './song.service';
+
+describe('SongService', () => {
+  let service: SongService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [SongService],
+    }).compile();
+
+    service = module.get<SongService>(SongService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/v2/song/song.service.ts
+++ b/src/v2/song/song.service.ts
@@ -1,0 +1,21 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from 'prisma/prisma.service';
+import { LyricsResponseDto } from './dto/lyrics-response.dto';
+
+@Injectable()
+export class SongService {
+  constructor(private readonly prisma: PrismaService) {}
+  // 특정 노래의 가사 정보 조회
+  async getSongLyrics(id: number) {
+    // 곡 ID가 유효한지 확인
+    const song = await this.prisma.song.findUnique({
+      where: { id },
+    });
+
+    if (!song) {
+      throw new NotFoundException('해당 곡이 존재하지 않습니다.');
+    }
+
+    return new LyricsResponseDto(song);
+  }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#80 

## 📝 요약(Summary)

- 특정 콘서트의 대표 셋리스트 조회 api 구현
- 특정 셋리스트 노래 목록 조회 api v2 구현
- 특정 셋리스트 상세 정보 조회 api v2 구현
- 특정 노래의 가사 조회 api v2 구현
- 특정 노래 응원법 조회 api v2 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
