### PR TITLE
✨ Feat: #102 홈 섹션 목록 조회 API 구현 및 콘서트 목록 조회 API 수정

### DIFF
--- a/prisma/migrations/20250825150513_delete_sorted_index_add_schedule_type/migration.sql
+++ b/prisma/migrations/20250825150513_delete_sorted_index_add_schedule_type/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `sorted_index` on the `concerts` table. All the data in the column will be lost.
+
+*/
+-- DropIndex
+DROP INDEX `concerts_sorted_index_idx` ON `concerts`;
+
+-- DropIndex
+DROP INDEX `concerts_sorted_index_key` ON `concerts`;
+
+-- AlterTable
+ALTER TABLE `concerts` DROP COLUMN `sorted_index`;
+
+-- AlterTable
+ALTER TABLE `schedule` ADD COLUMN `type` ENUM('CONCERT', 'TICKETING') NULL;

--- a/prisma/migrations/20250825154526_concert_set_unique/migration.sql
+++ b/prisma/migrations/20250825154526_concert_set_unique/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[start_date,id]` on the table `concerts` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[title,id]` on the table `concerts` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX `concerts_start_date_id_key` ON `concerts`(`start_date`, `id`);
+
+-- CreateIndex
+CREATE UNIQUE INDEX `concerts_title_id_key` ON `concerts`(`title`, `id`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,7 +18,6 @@ model Concert {
   artist          String?          @db.VarChar(100)
   createdAt       DateTime         @default(now()) @map("created_at")
   updatedAt       DateTime         @updatedAt @map("updated_at")
-  sortedIndex     Int?             @unique @map("sorted_index")
   artistId        Int              @map("artist_id")
   ticketSite      String?          @map("ticket_site") @db.VarChar(50)
   ticketUrl       String?          @map("ticket_url") @db.VarChar(2048)
@@ -36,7 +35,6 @@ model Concert {
   searchConcertSections SearchConcertSection[]
   concertGenre ConcertGenre[]
 
-  @@index([sortedIndex])
   @@index([artistId], map: "concerts_artist_id_fkey")
   @@fulltext([title, artist])
   @@map("concerts")
@@ -95,6 +93,7 @@ model Schedule {
   createdAt   DateTime @default(now()) @map("created_at")
   updatedAt   DateTime @updatedAt @map("updated_at")
   concert     Concert  @relation(fields: [concertId], references: [id])
+  type ScheduleType?
 
   @@index([concertId], map: "schedule_concert_id_fkey")
   @@map("schedule")
@@ -292,4 +291,9 @@ enum GenreType {
   CLASSIC_JAZZ
   ACOUSTIC
   ELECTRONIC
+}
+
+enum ScheduleType {
+  CONCERT
+  TICKETING
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,9 @@ model Concert {
   concertGenre ConcertGenre[]
 
   @@index([artistId], map: "concerts_artist_id_fkey")
+  @@unique([startDate, id])
+  @@unique([title, id])
+  
   @@fulltext([title, artist])
   @@map("concerts")
 }

--- a/src/v3/app.module.ts
+++ b/src/v3/app.module.ts
@@ -5,6 +5,7 @@ import { GlobalResponseInterceptor } from './common/interceptors/global-response
 import { ConcertModule } from './concert/concert.module';
 import { SetlistModule } from './setlist/setlist.module';
 import { SongModule } from 'src/v2/song/song.module';
+import { HomeModule } from './home/home.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { SongModule } from 'src/v2/song/song.module';
     ConcertModule,
     SetlistModule,
     SongModule,
+    HomeModule,
   ],
   controllers: [],
   providers: [

--- a/src/v3/concert/concert.controller.ts
+++ b/src/v3/concert/concert.controller.ts
@@ -16,11 +16,7 @@ export class ConcertController {
     description: '콘서트 목록을 조회합니다.',
   })
   getConcerts(@Query() query: GetConcertsDto) {
-    return this.concertService.getConcerts(
-      query.filter,
-      query.cursor,
-      query.size,
-    );
+    return this.concertService.getConcerts(query.cursor, query.id, query.size);
   }
 
   // 콘서트 상세 조회

--- a/src/v3/concert/concert.service.ts
+++ b/src/v3/concert/concert.service.ts
@@ -1,6 +1,4 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { ConcertFilter } from '../common/enums/concert-filter.enum';
-import { ConcertStatus } from '@prisma/client';
 import { PrismaService } from 'prisma/prisma.service';
 import { ConcertResponseDto } from './dto/concert-response.dto';
 import { getDaysUntil } from '../common/utils/date.util';
@@ -15,51 +13,13 @@ import { SetlistResponseDto } from './dto/setlist-response.dto';
 export class ConcertService {
   constructor(private readonly prismaService: PrismaService) {}
   // 콘서트 목록 조회
-  async getConcerts(filter: ConcertFilter, cursor?: number, size?: number) {
-    let where = {};
-    let cursorObj: { id: number } | { sortedIndex: number } | undefined =
-      undefined;
-    let orderBy: { [key: string]: 'asc' | 'desc' }[] = [];
-
-    switch (filter) {
-      case ConcertFilter.NEW:
-        // 한달 이내 최신 등록된 콘서트
-        where = {
-          createdAt: {
-            gte: new Date(new Date().setMonth(new Date().getMonth() - 1)), // 한 달 전 날짜부터
-          },
-        };
-        orderBy = [{ id: 'desc' }]; // id 기준 내림차순 정렬 (최신 등록 순)
-        if (cursor !== undefined) {
-          cursorObj = { id: cursor };
-        }
-        break;
-
-      case ConcertFilter.UPCOMING:
-        where = {
-          status: ConcertStatus.UPCOMING,
-        };
-        orderBy = [{ sortedIndex: 'asc' }];
-        if (cursor !== undefined) {
-          cursorObj = { sortedIndex: cursor };
-        }
-        break;
-
-      case ConcertFilter.ALL:
-        orderBy = [{ sortedIndex: 'asc' }];
-        if (cursor !== undefined) {
-          cursorObj = { sortedIndex: cursor };
-        }
-        break;
-
-      default:
-        throw new Error(`Unsupported filter: ${filter}`);
-    }
+  async getConcerts(cursor?: string, id?: number, size?: number) {
+    const cursorValue =
+      cursor && id ? { startDate: cursor, id: Number(id) } : undefined;
 
     const concerts = await this.prismaService.concert.findMany({
-      where,
-      orderBy,
-      cursor: cursorObj,
+      orderBy: [{ startDate: 'desc' }, { id: 'asc' }],
+      cursor: cursorValue,
       take: size,
       skip: cursor ? 1 : 0,
     });
@@ -71,9 +31,10 @@ export class ConcertService {
 
     const nextCursor =
       concerts.length > 0
-        ? filter === ConcertFilter.NEW
-          ? concerts[concerts.length - 1].id
-          : concerts[concerts.length - 1].sortedIndex
+        ? {
+            startDate: concerts[concerts.length - 1].startDate,
+            id: concerts[concerts.length - 1].id,
+          }
         : null;
 
     return {

--- a/src/v3/concert/dto/concert-response.dto.ts
+++ b/src/v3/concert/dto/concert-response.dto.ts
@@ -10,7 +10,6 @@ export class ConcertResponseDto {
   poster: string;
   status: Concert['status'];
   daysLeft: number;
-  sortedIndex: number;
   ticketSite: string;
   ticketUrl: string;
   venue: string;
@@ -26,7 +25,6 @@ export class ConcertResponseDto {
     this.status = concert.status;
     this.poster = concert.poster;
     this.artist = concert.artist;
-    this.sortedIndex = concert.sortedIndex;
     this.daysLeft = daysLeft;
     this.ticketSite = concert.ticketSite;
     this.ticketUrl = concert.ticketUrl;

--- a/src/v3/concert/dto/get-concerts.dto.ts
+++ b/src/v3/concert/dto/get-concerts.dto.ts
@@ -1,30 +1,24 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsNumber, IsOptional, Min } from 'class-validator';
-import { ConcertFilter } from 'src/v3/common/enums/concert-filter.enum';
+import { IsNumber, IsOptional, Min } from 'class-validator';
 export class GetConcertsDto {
   @ApiProperty({
-    description: '콘서트 진행 상태',
-    default: 'ALL',
-    enum: ConcertFilter,
-    enumName: 'ConcertFilter',
-    example: 'ALL',
-    required: true,
-  })
-  @IsEnum(ConcertFilter, {
-    message: 'filter는 NEW | UPCOMING | ALL 중 하나여야 해요',
-  })
-  filter: ConcertFilter;
-
-  @ApiProperty({
-    description: '커서 (id 또는 sortedIndex)',
+    description: '커서 (startDate)',
     default: undefined,
     required: false,
     example: undefined,
   })
   @IsOptional()
+  cursor?: string;
+
+  @ApiProperty({
+    description: '콘서트의 ID',
+    required: false,
+    example: 1,
+  })
+  @IsOptional()
   @IsNumber()
-  @Min(0)
-  cursor?: number;
+  @Min(1)
+  id?: number;
 
   @ApiProperty({
     description: '가져올 데이터 개수',

--- a/src/v3/concert/dto/schedule-response.dto.ts
+++ b/src/v3/concert/dto/schedule-response.dto.ts
@@ -1,13 +1,15 @@
-import { Schedule } from '@prisma/client';
+import { Schedule, ScheduleType } from '@prisma/client';
 
 export class ScheduleResponseDto {
   id: number;
   category: string;
   scheduledAt: Date;
+  type: ScheduleType;
 
   constructor(schedule: Schedule) {
     this.id = schedule.id;
     this.category = schedule.category;
     this.scheduledAt = schedule.scheduledAt;
+    this.type = schedule.type;
   }
 }

--- a/src/v3/home/dto/home-section-response.dto.ts
+++ b/src/v3/home/dto/home-section-response.dto.ts
@@ -1,0 +1,21 @@
+import { Concert, HomeConcertSection, HomeSection } from '@prisma/client';
+
+export class HomeSectionResponseDto {
+  id: number;
+  sectionTitle: string;
+  sortedIndex: number;
+  concerts: (Concert & { sortedIndex: number })[];
+
+  constructor(
+    section: HomeSection & {
+      homeConcertSections: (HomeConcertSection & { concert: Concert })[];
+    },
+  ) {
+    this.id = section.id;
+    this.sectionTitle = section.sectionTitle;
+    this.concerts = section.homeConcertSections.map((hcs) => ({
+      ...hcs.concert,
+      sortedIndex: hcs.sortedIndex,
+    }));
+  }
+}

--- a/src/v3/home/home.controller.spec.ts
+++ b/src/v3/home/home.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HomeController } from './home.controller';
+
+describe('HomeController', () => {
+  let controller: HomeController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HomeController],
+    }).compile();
+
+    controller = module.get<HomeController>(HomeController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/v3/home/home.controller.ts
+++ b/src/v3/home/home.controller.ts
@@ -1,0 +1,19 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { HomeService } from './home.service';
+
+@ApiTags('홈')
+@Controller('api/v3/home')
+export class HomeController {
+  constructor(private readonly homeService: HomeService) {}
+
+  // 홈 화면 섹션 정보 조회
+  @Get()
+  @ApiOperation({
+    summary: '홈 화면 섹션 정보 조회',
+    description: '홈 화면 섹션 정보를 조회합니다.',
+  })
+  async getHomeSections() {
+    return this.homeService.getHomeSections();
+  }
+}

--- a/src/v3/home/home.module.ts
+++ b/src/v3/home/home.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { HomeController } from './home.controller';
+import { HomeService } from './home.service';
+import { PrismaService } from 'prisma/prisma.service';
+
+@Module({
+  controllers: [HomeController],
+  providers: [HomeService, PrismaService],
+})
+export class HomeModule {}

--- a/src/v3/home/home.service.spec.ts
+++ b/src/v3/home/home.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HomeService } from './home.service';
+
+describe('HomeService', () => {
+  let service: HomeService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [HomeService],
+    }).compile();
+
+    service = module.get<HomeService>(HomeService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/v3/home/home.service.ts
+++ b/src/v3/home/home.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'prisma/prisma.service';
+import { HomeSectionResponseDto } from './dto/home-section-response.dto';
+
+@Injectable()
+export class HomeService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // 홈 화면 섹션 정보 조회
+  async getHomeSections() {
+    const sections = await this.prisma.homeSection.findMany({
+      include: {
+        homeConcertSections: {
+          orderBy: {
+            sortedIndex: 'asc',
+          },
+          include: {
+            concert: true,
+          },
+        },
+      },
+    });
+    return sections.map((section) => new HomeSectionResponseDto(section));
+  }
+}


### PR DESCRIPTION
## #️⃣ Issue Number

#102 

## 📝 요약(Summary)
- 콘서트 일정에 타입 칼럼 추가
- 콘서트 목록 조회 정렬 시 startDate 활용하도록 변경
- 홈 섹션 목록 조회 api 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
