### PR TITLE
♻️ Refactor: #263 일부 기존 API v6에 맞게 수정

### DIFF
--- a/prisma/migrations/20260417060918_v6_model/migration.sql
+++ b/prisma/migrations/20260417060918_v6_model/migration.sql
@@ -1,0 +1,62 @@
+/*
+  Warnings:
+
+  - The values [CLASSIC_JAZZ,ACOUSTIC,ELECTRONIC] on the enum `user_genres_genre_name` will be removed. If these variants are still used in the database, this will fail.
+  - The values [CLASSIC_JAZZ,ACOUSTIC,ELECTRONIC] on the enum `user_genres_genre_name` will be removed. If these variants are still used in the database, this will fail.
+  - The values [TICKETING] on the enum `schedule_type` will be removed. If these variants are still used in the database, this will fail.
+  - The values [CLASSIC_JAZZ,ACOUSTIC,ELECTRONIC] on the enum `user_genres_genre_name` will be removed. If these variants are still used in the database, this will fail.
+  - You are about to drop the column `interest_concert_id` on the `users` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE `users` DROP FOREIGN KEY `users_interest_concert_id_fkey`;
+
+-- DropIndex
+DROP INDEX `users_interest_concert_id_fkey` ON `users`;
+
+-- AlterTable
+ALTER TABLE `artists` ADD COLUMN `twitter_url` VARCHAR(2048) NULL;
+
+-- AlterTable
+ALTER TABLE `concert_genres` MODIFY `name` ENUM('JPOP', 'ROCK_METAL', 'RAP_HIPHOP', 'POP', 'INDIE') NOT NULL;
+
+-- AlterTable
+ALTER TABLE `concerts` MODIFY `title` VARCHAR(300) NULL,
+    MODIFY `start_date` VARCHAR(20) NULL,
+    MODIFY `end_date` VARCHAR(20) NULL,
+    MODIFY `poster` VARCHAR(2048) NULL,
+    MODIFY `venue` VARCHAR(100) NULL;
+
+-- AlterTable
+ALTER TABLE `genres` MODIFY `name` ENUM('JPOP', 'ROCK_METAL', 'RAP_HIPHOP', 'POP', 'INDIE') NOT NULL;
+
+-- AlterTable
+ALTER TABLE `schedule` MODIFY `type` ENUM('CONCERT', 'PRE_TICKETING', 'GENERAL_TICKETING') NULL;
+
+-- AlterTable
+ALTER TABLE `user_genres` MODIFY `genre_name` ENUM('JPOP', 'ROCK_METAL', 'RAP_HIPHOP', 'POP', 'INDIE') NOT NULL;
+
+-- AlterTable
+ALTER TABLE `users` DROP COLUMN `interest_concert_id`;
+
+-- CreateTable
+CREATE TABLE `user_interest_concerts` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `user_id` INTEGER NOT NULL,
+    `concert_id` INTEGER NOT NULL,
+    `concert_title` VARCHAR(300) NULL,
+    `user_nickname` VARCHAR(50) NOT NULL,
+    `created_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    INDEX `user_interest_concerts_user_id_idx`(`user_id`),
+    INDEX `user_interest_concerts_concert_id_idx`(`concert_id`),
+    UNIQUE INDEX `user_interest_concerts_user_id_concert_id_key`(`user_id`, `concert_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `user_interest_concerts` ADD CONSTRAINT `user_interest_concerts_user_id_fkey` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `user_interest_concerts` ADD CONSTRAINT `user_interest_concerts_concert_id_fkey` FOREIGN KEY (`concert_id`) REFERENCES `concerts`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,18 +10,18 @@ datasource db {
 model Concert {
   id                    Int                    @id @default(autoincrement())
   code                  String?                @unique @db.VarChar(20)
-  title                 String                 @unique(map: "uk_title") @db.VarChar(300)
-  startDate             String                 @map("start_date") @db.VarChar(20)
-  endDate               String                 @map("end_date") @db.VarChar(20)
+  title                 String?                @unique(map: "uk_title") @db.VarChar(300)
+  startDate             String?                 @map("start_date") @db.VarChar(20)
+  endDate               String?                 @map("end_date") @db.VarChar(20)
   status                ConcertStatus
-  poster                String                 @db.VarChar(2048)
+  poster                String?                 @db.VarChar(2048)
   artist                String                 @db.VarChar(100)
   createdAt             DateTime               @default(now()) @map("created_at")
   updatedAt             DateTime               @default(now()) @updatedAt @map("updated_at")
   artistId              Int                    @map("artist_id")
   ticketSite            String?                @map("ticket_site") @db.VarChar(50)
   ticketUrl             String?                @map("ticket_url") @db.VarChar(2048)
-  venue                 String                 @db.VarChar(100)
+  venue                 String?                 @db.VarChar(100)
   introduction          String                 @db.Text
   label                 String?                @db.VarChar(50)
   concertComments       ConcertComment[]
@@ -34,7 +34,7 @@ model Concert {
   mdItems               Md[]
   schedules             Schedule[]
   searchConcertSections SearchConcertSection[]
-  user                  User[]
+  userInterestConcerts  UserInterestConcert[]
 
   @@unique([startDate, id])
   @@unique([title, id])
@@ -49,6 +49,7 @@ model Artist {
   category     String?   @db.VarChar(30)
   detail       String?   @db.Text
   instagramUrl String?   @map("instagram_url") @db.VarChar(2048)
+  twitterUrl   String?   @map("twitter_url") @db.VarChar(2048)
   keywords     String?   @db.VarChar(100)
   imgUrl       String?   @map("img_url") @db.VarChar(2048)
   createdAt    DateTime  @default(now()) @map("created_at")
@@ -295,7 +296,6 @@ model Genre {
 
 model User {
   id                    Int              @id @default(autoincrement())
-  interestConcertId     Int?             @map("interest_concert_id")
   provider              Provider
   providerId            String?          @unique @map("provider_id")
   email                 String?          @db.VarChar(255)
@@ -307,13 +307,14 @@ model User {
   refreshToken          String?          @map("refresh_token") @db.Text
   refreshTokenExpiresAt DateTime?        @map("refresh_token_expires_at")
   concertComments       ConcertComment[]
-  concert               Concert?         @relation(fields: [interestConcertId], references: [id])
   userGenres            UserGenre[]
   userArtists   UserArtist[]
   fcmTokens             FcmToken[]
   notificationSet       NotificationSet?
   notificationhistories NotificationHistories[]
   notificationConsents  NotificationConsent[]
+  userInterestConcerts  UserInterestConcert[]
+
 
   @@map("users")
 }
@@ -366,6 +367,24 @@ model UserArtist {
   @@index([userId])
   @@index([artistId])
   @@map("user_artists")
+}
+
+model UserInterestConcert {
+  id         Int      @id @default(autoincrement())
+  userId     Int      @map("user_id")
+  concertId   Int      @map("concert_id")
+  concerTitle String?   @map("concert_title") @db.VarChar(300)
+  userNickname String   @map("user_nickname") @db.VarChar(50)
+  createdAt  DateTime @default(now()) @map("created_at")
+  updatedAt  DateTime @default(now()) @updatedAt @map("updated_at")
+  
+  user   User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  concert   Concert  @relation(fields: [concertId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, concertId]) 
+  @@index([userId])
+  @@index([concertId])
+  @@map("user_interest_concerts")
 }
 
 model ConcertComment {
@@ -494,9 +513,8 @@ enum GenreType {
   JPOP
   ROCK_METAL
   RAP_HIPHOP
-  CLASSIC_JAZZ
-  ACOUSTIC
-  ELECTRONIC
+  POP
+  INDIE
 }
 
 enum NotificationType{
@@ -520,7 +538,8 @@ enum ConsentType{
 
 enum ScheduleType {
   CONCERT
-  TICKETING
+  PRE_TICKETING
+  GENERAL_TICKETING
 }
 
 enum Provider {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -373,7 +373,7 @@ model UserInterestConcert {
   id         Int      @id @default(autoincrement())
   userId     Int      @map("user_id")
   concertId   Int      @map("concert_id")
-  concerTitle String?   @map("concert_title") @db.VarChar(300)
+  concertTitle String?   @map("concert_title") @db.VarChar(300)
   userNickname String   @map("user_nickname") @db.VarChar(50)
   createdAt  DateTime @default(now()) @map("created_at")
   updatedAt  DateTime @default(now()) @updatedAt @map("updated_at")

--- a/src/common/utils/date.util.ts
+++ b/src/common/utils/date.util.ts
@@ -3,8 +3,10 @@ const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
 export const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
 
 function parseYmd(
-  dateStr: string,
+  dateStr?: string | null,
 ): { year: number; month: number; day: number } | null {
+  if (!dateStr) return null;
+
   const match = dateStr.match(/(\d{4})[./-](\d{1,2})[./-](\d{1,2})/);
   if (!match) return null;
 
@@ -30,7 +32,9 @@ function getTodayKstYmd(): { year: number; month: number; day: number } {
   };
 }
 
-export function getDaysUntil(dateStr: string): number {
+export function getDaysUntil(dateStr?: string | null): number | null {
+  if (dateStr == null) return null;
+
   const target = parseYmd(dateStr);
   if (!target) return 0;
 
@@ -103,7 +107,12 @@ export function formatKstDateTime(date: Date): string {
 /**
  * 콘서트 D-day 계산(다일 공연)
  */
-export function getConcertDaysLeft(startDate: string, endDate: string): number {
+export function getConcertDaysLeft(
+  startDate?: string | null,
+  endDate?: string | null,
+): number | null {
+  if (startDate == null || endDate == null) return null;
+
   const today = getTodayKstYmd();
   const todayUtcMs = Date.UTC(today.year, today.month - 1, today.day);
   const start = parseYmd(startDate);

--- a/src/concert/dto/artist-response.dto.ts
+++ b/src/concert/dto/artist-response.dto.ts
@@ -14,7 +14,7 @@ export class ArtistResponseDto {
   constructor(artist: Artist) {
     this.id = artist.id;
     this.artist = artist.artist;
-    this.debutDate = artist.debutDate.replaceAll('-', '.');
+    this.debutDate = artist.debutDate.replaceAll('-', '.') ?? null;
     this.category = artist.category;
     this.detail = artist.detail;
     this.instagramUrl = artist.instagramUrl;

--- a/src/concert/dto/artist-response.dto.ts
+++ b/src/concert/dto/artist-response.dto.ts
@@ -7,6 +7,7 @@ export class ArtistResponseDto {
   category: string;
   detail: string;
   instagramUrl: string;
+  twitterUrl: string;
   keywords: string[];
   imgUrl: string;
 
@@ -17,6 +18,7 @@ export class ArtistResponseDto {
     this.category = artist.category;
     this.detail = artist.detail;
     this.instagramUrl = artist.instagramUrl;
+    this.twitterUrl = artist.twitterUrl;
     this.keywords = artist.keywords
       ? artist.keywords.split(',').map((keyword) => keyword.trim())
       : [];

--- a/src/concert/dto/concert-response.dto.ts
+++ b/src/concert/dto/concert-response.dto.ts
@@ -16,12 +16,16 @@ export class ConcertResponseDto {
   introduction: string;
   label: string;
 
+  private static formatDate(date: string | null): string | null {
+    return date ? date.replaceAll('-', '.') : null;
+  }
+
   constructor(concert: Concert, daysLeft?: number) {
     this.id = concert.id;
     this.code = concert.code;
     this.title = concert.title;
-    this.startDate = concert.startDate.replaceAll('-', '.');
-    this.endDate = concert.endDate.replaceAll('-', '.');
+    this.startDate = ConcertResponseDto.formatDate(concert.startDate);
+    this.endDate = ConcertResponseDto.formatDate(concert.endDate);
     this.status = concert.status;
     this.poster = concert.poster;
     this.artist = concert.artist;

--- a/src/user/dto/user-response.dto.ts
+++ b/src/user/dto/user-response.dto.ts
@@ -2,33 +2,23 @@ import { User, UserArtist, UserGenre } from '@prisma/client';
 
 export class UserResponseDto {
   id: number;
-  interestConcertId: number;
   title: string;
   provider: string;
   providerId: string;
   email: string;
   nickname: string;
   marketingConsent: boolean;
-  preferredGenres: { id: number; name: string }[];
-  preferredArtists: { id: number; name: string }[];
+  hasPreferredGenre: boolean;
 
   constructor(
     user: User & { userGenres?: UserGenre[]; userArtists?: UserArtist[] },
   ) {
     this.id = user.id;
-    this.interestConcertId = user.interestConcertId;
     this.provider = user.provider;
     this.providerId = user.providerId;
     this.email = user.email;
     this.nickname = user.nickname;
     this.marketingConsent = user.marketingConsent;
-    this.preferredGenres = (user.userGenres || []).map((ug) => ({
-      id: ug.genreId,
-      name: ug.genreName,
-    }));
-    this.preferredArtists = (user.userArtists || []).map((ua) => ({
-      id: ua.artistId,
-      name: ua.artistName,
-    }));
+    this.hasPreferredGenre = !!user.userGenres && user.userGenres.length > 0;
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -95,7 +95,6 @@ export class UserService {
       where: { id: userId },
       include: {
         userGenres: true,
-        userArtists: true,
       },
     });
     await this.validateUser(userId);


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

- 유저 정보 조회 API 수정 (관심 콘서트 Id 삭제, 선호 장르 선택 여부로 변경)
- 특정 콘서트 상세 조회 API 수정 (startdate, enddate null일 때 계산 시 오류 안 나도록 변경)
- 특정 콘서트 아티스트 조회 API 수정 (트위터 url 추가)

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어

콘서트의 칼럼 중 nullable한 것들이 많아지면서 전에 구현했던 콘서트 값 반환하는 api들 중에 null일 때 오류 안 나는지 각자 맡았었던 api 한번 확인해 봐야 할것 같아요.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
