### PR TITLE
✨ feat: 선예매·일반예매 알림 6종 추가 및 레거시 타입 정리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ NestJS modular architecture with 14 feature modules registered in `src/app.modul
 - Each feature module follows Controller → Service → PrismaService pattern.
 - DTOs use `class-validator` decorators for request validation and `@ApiProperty()` for Swagger.
 - Dates handled with `dayjs` (see `common/utils/date.util.ts`).
-- Notification types are enumerated in `NotificationType` (INTEREST_CONCERT, TICKET_7D, TICKET_1D, TICKET_TODAY, etc.).
+- Notification types are enumerated in `NotificationType` (INTEREST_CONCERT, PRE_TICKETING_OPEN, GENERAL_TICKETING_OPEN, PRE_TICKETING_1D, GENERAL_TICKETING_1D, PRE_TICKETING_30MIN, GENERAL_TICKETING_30MIN, etc.).
 
 ## Deployment
 

--- a/prisma/migrations/20260420183405_add_pre_general_ticketing_notifications/migration.sql
+++ b/prisma/migrations/20260420183405_add_pre_general_ticketing_notifications/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The values [TICKET_7D,TICKET_1D,TICKET_TODAY] on the enum `notificationhistories_type` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE `notificationhistories` ADD COLUMN `schedule_id` INTEGER NULL,
+    MODIFY `type` ENUM('INTEREST_CONCERT', 'PRE_TICKETING_OPEN', 'GENERAL_TICKETING_OPEN', 'PRE_TICKETING_1D', 'GENERAL_TICKETING_1D', 'PRE_TICKETING_30MIN', 'GENERAL_TICKETING_30MIN', 'CONCERT_INFO_UPDATE_SETLIST', 'CONCERT_INFO_UPDATE_MD', 'CONCERT_INFO_UPDATE_DETAIL', 'CONCERT_INFO_UPDATE_SCHEDULE', 'CONCERT_INFO_UPDATE_TICKET', 'ARTIST_CONCERT_OPEN', 'RECOMMEND') NOT NULL;
+
+-- CreateIndex
+CREATE INDEX `notificationhistories_schedule_id_type_idx` ON `notificationhistories`(`schedule_id`, `type`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,17 +11,17 @@ model Concert {
   id                    Int                    @id @default(autoincrement())
   code                  String?                @unique @db.VarChar(20)
   title                 String?                @unique(map: "uk_title") @db.VarChar(300)
-  startDate             String?                 @map("start_date") @db.VarChar(20)
-  endDate               String?                 @map("end_date") @db.VarChar(20)
+  startDate             String?                @map("start_date") @db.VarChar(20)
+  endDate               String?                @map("end_date") @db.VarChar(20)
   status                ConcertStatus
-  poster                String?                 @db.VarChar(2048)
+  poster                String?                @db.VarChar(2048)
   artist                String                 @db.VarChar(100)
   createdAt             DateTime               @default(now()) @map("created_at")
   updatedAt             DateTime               @default(now()) @updatedAt @map("updated_at")
   artistId              Int                    @map("artist_id")
   ticketSite            String?                @map("ticket_site") @db.VarChar(50)
   ticketUrl             String?                @map("ticket_url") @db.VarChar(2048)
-  venue                 String?                 @db.VarChar(100)
+  venue                 String?                @db.VarChar(100)
   introduction          String                 @db.Text
   label                 String?                @db.VarChar(50)
   concertComments       ConcertComment[]
@@ -274,7 +274,7 @@ model ConcertGenre {
   concertId    Int       @map("concert_id")
   concertTitle String    @map("concert_title") @db.VarChar(300)
   genreId      Int       @map("genre_id")
-  name         GenreType 
+  name         GenreType
   concert      Concert   @relation(fields: [concertId], references: [id])
   genre        Genre     @relation(fields: [genreId], references: [id])
 
@@ -284,9 +284,9 @@ model ConcertGenre {
 }
 
 model Genre {
-  id                    Int                         @id @default(autoincrement())
-  name                  GenreType                   @unique
-  imgUrl                String                      @map("img_url") @db.VarChar(2048)
+  id                    Int                    @id @default(autoincrement())
+  name                  GenreType              @unique
+  imgUrl                String                 @map("img_url") @db.VarChar(2048)
   concertGenre          ConcertGenre[]
   userGenres            UserGenre[]
   representativeArtists RepresentativeArtist[]
@@ -295,37 +295,36 @@ model Genre {
 }
 
 model User {
-  id                    Int              @id @default(autoincrement())
+  id                    Int                     @id @default(autoincrement())
   provider              Provider
-  providerId            String?          @unique @map("provider_id")
-  email                 String?          @db.VarChar(255)
-  nickname              String           @unique @db.VarChar(50)
-  marketingConsent      Boolean          @default(false) @map("marketing_consent")
-  createdAt             DateTime         @default(now()) @map("created_at")
-  updatedAt             DateTime         @default(now()) @updatedAt @map("updated_at")
-  deletedAt             DateTime?        @map("deleted_at")
-  refreshToken          String?          @map("refresh_token") @db.Text
-  refreshTokenExpiresAt DateTime?        @map("refresh_token_expires_at")
+  providerId            String?                 @unique @map("provider_id")
+  email                 String?                 @db.VarChar(255)
+  nickname              String                  @unique @db.VarChar(50)
+  marketingConsent      Boolean                 @default(false) @map("marketing_consent")
+  createdAt             DateTime                @default(now()) @map("created_at")
+  updatedAt             DateTime                @default(now()) @updatedAt @map("updated_at")
+  deletedAt             DateTime?               @map("deleted_at")
+  refreshToken          String?                 @map("refresh_token") @db.Text
+  refreshTokenExpiresAt DateTime?               @map("refresh_token_expires_at")
   concertComments       ConcertComment[]
   userGenres            UserGenre[]
-  userArtists   UserArtist[]
+  userArtists           UserArtist[]
   fcmTokens             FcmToken[]
   notificationSet       NotificationSet?
   notificationhistories NotificationHistories[]
   notificationConsents  NotificationConsent[]
   userInterestConcerts  UserInterestConcert[]
 
-
   @@map("users")
 }
 
 model UserGenre {
-  id            Int         @id @default(autoincrement())
-  userId        Int         @map("user_id")
-  genreId       Int         @map("genre_id")
-  genreName    GenreType    @map("genre_name")
-  createdAt     DateTime    @default(now()) @map("created_at")
-  updatedAt     DateTime    @default(now()) @updatedAt @map("updated_at")
+  id        Int       @id @default(autoincrement())
+  userId    Int       @map("user_id")
+  genreId   Int       @map("genre_id")
+  genreName GenreType @map("genre_name")
+  createdAt DateTime  @default(now()) @map("created_at")
+  updatedAt DateTime  @default(now()) @updatedAt @map("updated_at")
 
   user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
   genre Genre @relation(fields: [genreId], references: [id])
@@ -344,7 +343,7 @@ model RepresentativeArtist {
   createdAt  DateTime @default(now()) @map("created_at")
   updatedAt  DateTime @default(now()) @updatedAt @map("updated_at")
 
-  genre Genre @relation(fields: [genreId], references: [id])
+  genre       Genre        @relation(fields: [genreId], references: [id])
   userArtists UserArtist[]
 
   @@unique([genreId, artistName])
@@ -359,29 +358,29 @@ model UserArtist {
   artistName String   @map("artist_name") @db.VarChar(100)
   createdAt  DateTime @default(now()) @map("created_at")
   updatedAt  DateTime @default(now()) @updatedAt @map("updated_at")
-  
-  user   User  @relation(fields: [userId], references: [id], onDelete: Cascade)
-  artist RepresentativeArtist @relation(fields: [artistId], references: [id]) 
 
-  @@unique([userId, artistId]) 
+  user   User                 @relation(fields: [userId], references: [id], onDelete: Cascade)
+  artist RepresentativeArtist @relation(fields: [artistId], references: [id])
+
+  @@unique([userId, artistId])
   @@index([userId])
   @@index([artistId])
   @@map("user_artists")
 }
 
 model UserInterestConcert {
-  id         Int      @id @default(autoincrement())
-  userId     Int      @map("user_id")
-  concertId   Int      @map("concert_id")
-  concertTitle String?   @map("concert_title") @db.VarChar(300)
+  id           Int      @id @default(autoincrement())
+  userId       Int      @map("user_id")
+  concertId    Int      @map("concert_id")
+  concertTitle String?  @map("concert_title") @db.VarChar(300)
   userNickname String   @map("user_nickname") @db.VarChar(50)
-  createdAt  DateTime @default(now()) @map("created_at")
-  updatedAt  DateTime @default(now()) @updatedAt @map("updated_at")
-  
-  user   User  @relation(fields: [userId], references: [id], onDelete: Cascade)
-  concert   Concert  @relation(fields: [concertId], references: [id], onDelete: Cascade)
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @default(now()) @updatedAt @map("updated_at")
 
-  @@unique([userId, concertId]) 
+  user    User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  concert Concert @relation(fields: [concertId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, concertId])
   @@index([userId])
   @@index([concertId])
   @@map("user_interest_concerts")
@@ -417,16 +416,16 @@ model FcmToken {
 }
 
 model NotificationSet {
-  id              Int      @id @default(autoincrement())
-  userId          Int      @unique @map("user_id")
-  benefitAlert    Boolean  @default(false) @map("benefit_alert")
-  nightAlert      Boolean  @default(false) @map("night_alert")
-  ticketAlert     Boolean  @default(true)  @map("ticket_alert")
-  infoAlert       Boolean  @default(true)  @map("info_alert")
-  interestAlert   Boolean  @default(true)  @map("interest_alert")
-  recommendAlert  Boolean  @default(false) @map("recommend_alert")
-  createdAt       DateTime @default(now()) @map("created_at")
-  updatedAt       DateTime @default(now()) @updatedAt @map("updated_at")
+  id             Int      @id @default(autoincrement())
+  userId         Int      @unique @map("user_id")
+  benefitAlert   Boolean  @default(false) @map("benefit_alert")
+  nightAlert     Boolean  @default(false) @map("night_alert")
+  ticketAlert    Boolean  @default(true) @map("ticket_alert")
+  infoAlert      Boolean  @default(true) @map("info_alert")
+  interestAlert  Boolean  @default(true) @map("interest_alert")
+  recommendAlert Boolean  @default(false) @map("recommend_alert")
+  createdAt      DateTime @default(now()) @map("created_at")
+  updatedAt      DateTime @default(now()) @updatedAt @map("updated_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -434,20 +433,22 @@ model NotificationSet {
   @@map("notification_sets")
 }
 
-model NotificationHistories{
-  id          Int       @id @default(autoincrement())
-  userId      Int       @map("user_id")
-  type        NotificationType
-  title       String    @db.VarChar(100)
-  content     String    @db.VarChar(500)
-  targetId    String?   @map("target_id") @db.VarChar(500)
-  isRead      Boolean   @default(false) @map("is_read")
-  createdAt   DateTime  @default(now()) @map("created_at")
+model NotificationHistories {
+  id        Int              @id @default(autoincrement())
+  userId    Int              @map("user_id")
+  type      NotificationType
+  title     String           @db.VarChar(100)
+  content   String           @db.VarChar(500)
+  targetId  String?          @map("target_id") @db.VarChar(500)
+  scheduleId Int?             @map("schedule_id")
+  isRead    Boolean          @default(false) @map("is_read")
+  createdAt DateTime         @default(now()) @map("created_at")
 
-  user    User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId, createdAt])
   @@index([userId, isRead])
+  @@index([scheduleId, type])
   @@map("notificationhistories")
 }
 
@@ -462,12 +463,12 @@ model ConcertNotificationQueue {
   @@map("concert_notification_queue")
 }
 
-model NotificationConsent{
-  id         Int        @id @default(autoincrement())
-  userId     Int        @map("user_id")
-  type       ConsentType
-  isAgreed   Boolean    @map("is_agreed")
-  agreedAt   DateTime   @default(now()) @map("agreed_at")
+model NotificationConsent {
+  id       Int         @id @default(autoincrement())
+  userId   Int         @map("user_id")
+  type     ConsentType
+  isAgreed Boolean     @map("is_agreed")
+  agreedAt DateTime    @default(now()) @map("agreed_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -517,11 +518,15 @@ enum GenreType {
   INDIE
 }
 
-enum NotificationType{
+enum NotificationType {
   INTEREST_CONCERT
-  TICKET_7D
-  TICKET_1D
-  TICKET_TODAY
+
+  PRE_TICKETING_OPEN
+  GENERAL_TICKETING_OPEN
+  PRE_TICKETING_1D
+  GENERAL_TICKETING_1D
+  PRE_TICKETING_30MIN
+  GENERAL_TICKETING_30MIN
   CONCERT_INFO_UPDATE_SETLIST
   CONCERT_INFO_UPDATE_MD
   CONCERT_INFO_UPDATE_DETAIL
@@ -531,7 +536,7 @@ enum NotificationType{
   RECOMMEND
 }
 
-enum ConsentType{
+enum ConsentType {
   BENEFIT_PUSH
   NIGHT_PUSH
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -434,15 +434,15 @@ model NotificationSet {
 }
 
 model NotificationHistories {
-  id        Int              @id @default(autoincrement())
-  userId    Int              @map("user_id")
-  type      NotificationType
-  title     String           @db.VarChar(100)
-  content   String           @db.VarChar(500)
-  targetId  String?          @map("target_id") @db.VarChar(500)
+  id         Int              @id @default(autoincrement())
+  userId     Int              @map("user_id")
+  type       NotificationType
+  title      String           @db.VarChar(100)
+  content    String           @db.VarChar(500)
+  targetId   String?          @map("target_id") @db.VarChar(500)
   scheduleId Int?             @map("schedule_id")
-  isRead    Boolean          @default(false) @map("is_read")
-  createdAt DateTime         @default(now()) @map("created_at")
+  isRead     Boolean          @default(false) @map("is_read")
+  createdAt  DateTime         @default(now()) @map("created_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -520,7 +520,6 @@ enum GenreType {
 
 enum NotificationType {
   INTEREST_CONCERT
-
   PRE_TICKETING_OPEN
   GENERAL_TICKETING_OPEN
   PRE_TICKETING_1D

--- a/src/notification/constants/notification.constants.ts
+++ b/src/notification/constants/notification.constants.ts
@@ -98,9 +98,12 @@ export const NOTIFICATION_TYPE_TO_SET_FIELD: Record<
   NotificationField
 > = {
   [NotificationType.INTEREST_CONCERT]: NotificationField.INTEREST_ALERT,
-  [NotificationType.TICKET_7D]: NotificationField.TICKET_ALERT,
-  [NotificationType.TICKET_1D]: NotificationField.TICKET_ALERT,
-  [NotificationType.TICKET_TODAY]: NotificationField.TICKET_ALERT,
+  [NotificationType.PRE_TICKETING_OPEN]: NotificationField.TICKET_ALERT,
+  [NotificationType.GENERAL_TICKETING_OPEN]: NotificationField.TICKET_ALERT,
+  [NotificationType.PRE_TICKETING_1D]: NotificationField.TICKET_ALERT,
+  [NotificationType.GENERAL_TICKETING_1D]: NotificationField.TICKET_ALERT,
+  [NotificationType.PRE_TICKETING_30MIN]: NotificationField.TICKET_ALERT,
+  [NotificationType.GENERAL_TICKETING_30MIN]: NotificationField.TICKET_ALERT,
   [NotificationType.CONCERT_INFO_UPDATE_SETLIST]: NotificationField.INFO_ALERT,
   [NotificationType.CONCERT_INFO_UPDATE_MD]: NotificationField.INFO_ALERT,
   [NotificationType.CONCERT_INFO_UPDATE_DETAIL]: NotificationField.INFO_ALERT,

--- a/src/notification/dto/request/test-notification.dto.ts
+++ b/src/notification/dto/request/test-notification.dto.ts
@@ -6,7 +6,7 @@ export class TestNotificationDto {
   @ApiProperty({
     description: '알림 타입',
     enum: NotificationType,
-    example: NotificationType.TICKET_7D,
+    example: NotificationType.PRE_TICKETING_OPEN,
   })
   @IsEnum(NotificationType)
   type: NotificationType;

--- a/src/notification/scheduler/ticketing-reminder.scheduler.ts
+++ b/src/notification/scheduler/ticketing-reminder.scheduler.ts
@@ -87,7 +87,7 @@ export class TicketingReminderScheduler {
 
     for (const schedule of schedules) {
       const timeStr = formatKstHour(schedule.scheduledAt);
-      await this.notificationService.sendTicketReminderNotification(
+      await this.notificationService.sendNotificationByStrategy(
         notificationType,
         {
           scheduleId: schedule.id,
@@ -127,7 +127,7 @@ export class TicketingReminderScheduler {
       if (already) continue;
 
       const timeStr = formatKstHour(schedule.scheduledAt);
-      await this.notificationService.sendTicketReminderNotification(
+      await this.notificationService.sendNotificationByStrategy(
         notificationType,
         {
           scheduleId: schedule.id,
@@ -168,7 +168,7 @@ export class TicketingReminderScheduler {
       if (already) continue;
 
       const timeStr = formatKstHour(schedule.scheduledAt);
-      await this.notificationService.sendTicketReminderNotification(
+      await this.notificationService.sendNotificationByStrategy(
         notificationType,
         {
           scheduleId: schedule.id,

--- a/src/notification/scheduler/ticketing-reminder.scheduler.ts
+++ b/src/notification/scheduler/ticketing-reminder.scheduler.ts
@@ -2,68 +2,84 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'prisma/prisma.service';
 import { NotificationService } from '../service/notification.service';
 import { Cron } from '@nestjs/schedule';
-import { NotificationType } from '@prisma/client';
+import { NotificationType, ScheduleType } from '@prisma/client';
 import { formatKstHour, getKstDayRange } from 'src/common/utils/date.util';
 import { SchedulerMetricsService } from '../../metrics/scheduler-metrics.service';
 import { InstrumentJob } from '../../metrics/instrument-job.decorator';
+import { NotificationHistoryService } from '../service/notification-history.service';
 
 @Injectable()
 export class TicketingReminderScheduler {
   constructor(
     private readonly prisma: PrismaService,
     private readonly notificationService: NotificationService,
+    private readonly historyService: NotificationHistoryService,
     readonly schedulerMetrics: SchedulerMetricsService,
   ) {}
 
-  @InstrumentJob('ticketing_reminder')
+  /**
+   * 1일 전 알림: 매일 오전 10시 일괄 발송
+   * PRE_TICKETING_1D / GENERAL_TICKETING_1D
+   */
+  @InstrumentJob('ticketing_reminder_1d')
   @Cron('0 10 * * *', { timeZone: 'Asia/Seoul' })
-  async dailyTicketingNotifications(): Promise<number> {
-    const count7d = await this.sendTicketingReminders(
-      7,
-      NotificationType.TICKET_7D,
+  async oneDayBeforeNotification(): Promise<number> {
+    const pre = await this.sendOneDayBefore(
+      ScheduleType.PRE_TICKETING,
+      NotificationType.PRE_TICKETING_1D,
     );
-    const count1d = await this.sendTicketingReminders(
-      1,
-      NotificationType.TICKET_1D,
+    const general = await this.sendOneDayBefore(
+      ScheduleType.GENERAL_TICKETING,
+      NotificationType.GENERAL_TICKETING_1D,
     );
-    const countToday = await this.sendTicketingRemindersForToday();
-
-    return count7d + count1d + countToday;
+    return pre + general;
   }
 
-  private async sendTicketingReminders(
-    daysFromToday: number,
-    type: NotificationType,
+  /**
+   * 30분 전: 1분마다 29~31분 윈도우 스캔
+   * PRE_TICKETING_30MIN / GENERAL_TICKETING_30MIN
+   */
+  @InstrumentJob('ticketing_reminder_30min')
+  @Cron('* * * * *', { timeZone: 'Asia/Seoul' })
+  async thirtyMinBeforeNotifications(): Promise<number> {
+    const pre = await this.sendThirtyMinBefore(
+      ScheduleType.PRE_TICKETING,
+      NotificationType.PRE_TICKETING_30MIN,
+    );
+
+    const general = await this.sendThirtyMinBefore(
+      ScheduleType.GENERAL_TICKETING,
+      NotificationType.GENERAL_TICKETING_30MIN,
+    );
+    return pre + general;
+  }
+
+  /**
+   * 오픈 시점: 1분마다 과거 5분 ~ 현재 윈도우 스캔
+   * PRE_TICKETING_OPEN / GENERAL_TICKETING_OPEN
+   */
+  @InstrumentJob('ticketing_reminder_open')
+  @Cron('* * * * *', { timeZone: 'Asia/Seoul' })
+  async openTimeNotifications(): Promise<number> {
+    const pre = await this.sendOpenTime(
+      ScheduleType.PRE_TICKETING,
+      NotificationType.PRE_TICKETING_OPEN,
+    );
+    const general = await this.sendOpenTime(
+      ScheduleType.GENERAL_TICKETING,
+      NotificationType.GENERAL_TICKETING_OPEN,
+    );
+    return pre + general;
+  }
+
+  private async sendOneDayBefore(
+    scheduleType: ScheduleType,
+    notificationType: NotificationType,
   ): Promise<number> {
-    const { start, end } = getKstDayRange(daysFromToday);
+    const { start, end } = getKstDayRange(1);
     const schedules = await this.prisma.schedule.findMany({
       where: {
-        type: 'CONCERT',
-        scheduledAt: { gte: start, lte: end },
-      },
-      include: { concert: { select: { id: true, title: true } } },
-    });
-
-    for (const schedule of schedules) {
-      await this.notificationService.sendTicketReminderNotification(
-        type,
-        {
-          scheduleId: schedule.id,
-          concertTitle: schedule.concert.title,
-          daysUntil: daysFromToday,
-        },
-        String(schedule.concert.id),
-      );
-    }
-
-    return schedules.length;
-  }
-
-  private async sendTicketingRemindersForToday(): Promise<number> {
-    const { start, end } = getKstDayRange(0);
-    const schedules = await this.prisma.schedule.findMany({
-      where: {
-        type: 'CONCERT',
+        type: scheduleType,
         scheduledAt: { gte: start, lte: end },
       },
       include: { concert: { select: { id: true, title: true } } },
@@ -72,7 +88,47 @@ export class TicketingReminderScheduler {
     for (const schedule of schedules) {
       const timeStr = formatKstHour(schedule.scheduledAt);
       await this.notificationService.sendTicketReminderNotification(
-        NotificationType.TICKET_TODAY,
+        notificationType,
+        {
+          scheduleId: schedule.id,
+          concertTitle: schedule.concert.title,
+          timeStr,
+          daysUntil: 1,
+        },
+        String(schedule.concert.id),
+      );
+    }
+
+    return schedules.length;
+  }
+
+  private async sendThirtyMinBefore(
+    scheduleType: ScheduleType,
+    notificationType: NotificationType,
+  ): Promise<number> {
+    const now = new Date();
+    const start = new Date(now.getTime() + 29 * 60 * 1000);
+    const end = new Date(now.getTime() + 31 * 60 * 1000);
+
+    const schedules = await this.prisma.schedule.findMany({
+      where: {
+        type: scheduleType,
+        scheduledAt: { gte: start, lte: end },
+      },
+      include: { concert: { select: { id: true, title: true } } },
+    });
+
+    let sent = 0;
+    for (const schedule of schedules) {
+      const already = await this.historyService.existsByScheduleAndType(
+        schedule.id,
+        notificationType,
+      );
+      if (already) continue;
+
+      const timeStr = formatKstHour(schedule.scheduledAt);
+      await this.notificationService.sendTicketReminderNotification(
+        notificationType,
         {
           scheduleId: schedule.id,
           concertTitle: schedule.concert.title,
@@ -81,8 +137,50 @@ export class TicketingReminderScheduler {
         },
         String(schedule.concert.id),
       );
+      sent++;
     }
 
-    return schedules.length;
+    return sent;
+  }
+
+  private async sendOpenTime(
+    scheduleType: ScheduleType,
+    notificationType: NotificationType,
+  ): Promise<number> {
+    const now = new Date();
+    const start = new Date(now.getTime() - 5 * 60 * 1000);
+    const end = now;
+
+    const schedules = await this.prisma.schedule.findMany({
+      where: {
+        type: scheduleType,
+        scheduledAt: { gte: start, lte: end },
+      },
+      include: { concert: { select: { id: true, title: true } } },
+    });
+
+    let sent = 0;
+    for (const schedule of schedules) {
+      const already = await this.historyService.existsByScheduleAndType(
+        schedule.id,
+        notificationType,
+      );
+      if (already) continue;
+
+      const timeStr = formatKstHour(schedule.scheduledAt);
+      await this.notificationService.sendTicketReminderNotification(
+        notificationType,
+        {
+          scheduleId: schedule.id,
+          concertTitle: schedule.concert.title,
+          timeStr,
+          daysUntil: 0,
+        },
+        String(schedule.concert.id),
+      );
+      sent++;
+    }
+
+    return sent;
   }
 }

--- a/src/notification/service/notification-history.service.ts
+++ b/src/notification/service/notification-history.service.ts
@@ -105,6 +105,7 @@ export class NotificationHistoryService {
     title: string,
     content: string,
     targetId: string | null,
+    scheduleId: number | null = null,
   ): Promise<void> {
     if (userIds.length === 0) return;
 
@@ -115,9 +116,23 @@ export class NotificationHistoryService {
         title,
         content,
         targetId,
+        scheduleId,
         isRead: false,
       })),
     });
+  }
+
+  /**
+   * 특정 schedule에 이미 같은 타입 알림을 보낸 적이 있는지 확인(dedup용)
+   */
+  async existsByScheduleAndType(
+    scheduleId: number,
+    type: NotificationType,
+  ): Promise<boolean> {
+    const count = await this.prisma.notificationHistories.count({
+      where: { scheduleId, type },
+    });
+    return count > 0;
   }
 
   /**

--- a/src/notification/service/notification.service.ts
+++ b/src/notification/service/notification.service.ts
@@ -97,6 +97,7 @@ export class NotificationService {
     title: string;
     content: string;
     targetId?: string;
+    scheduleId?: number;
     userIds: number[];
   }): Promise<{ sent: number; failed: number }> {
     const result = await this.pushSenderService.sendPushNotification(params);
@@ -109,6 +110,7 @@ export class NotificationService {
         result.finalTitle,
         result.finalContent,
         params.targetId ?? null,
+        params.scheduleId ?? null,
       );
     }
 
@@ -116,7 +118,7 @@ export class NotificationService {
   }
 
   /**
-   * Straegy 패턴을 사용한 통합 알림 전송
+   * Strategy 패턴을 사용한 통합 알림 전송
    * - Strategy가 대상 유저와 메시지를 결정
    */
   async sendNotificationByStrategy(
@@ -177,7 +179,10 @@ export class NotificationService {
       return { sent: 0, failed: 0 };
     }
 
-    const message = await strategy.buildMessage(params);
+    const message = await strategy.buildMessage({
+      ...params,
+      notificationType: type,
+    });
 
     let totalSent = 0;
     let totalFailed = 0;
@@ -191,6 +196,7 @@ export class NotificationService {
           title: message.title,
           content: message.content,
           targetId,
+          scheduleId: params.scheduleId,
           userIds: batchUserIds,
         });
         totalSent += result.sent;

--- a/src/notification/service/notification.service.ts
+++ b/src/notification/service/notification.service.ts
@@ -154,48 +154,6 @@ export class NotificationService {
           title: message.title,
           content: message.content,
           targetId,
-          userIds: batchUserIds,
-        });
-        totalSent += result.sent;
-        totalFailed += result.failed;
-      },
-    );
-
-    return { sent: totalSent, failed: totalFailed };
-  }
-
-  /**
-   * Ticket Reminder 알림
-   */
-  async sendTicketReminderNotification(
-    type: NotificationType,
-    params: NotificationTargetParams,
-    targetId?: string,
-  ): Promise<{ sent: number; failed: number }> {
-    const strategy = this.strategyService.getStrategy(type);
-
-    const userIds = await strategy.getTargetUserIds(params);
-    if (userIds.length === 0) {
-      return { sent: 0, failed: 0 };
-    }
-
-    const message = await strategy.buildMessage({
-      ...params,
-      notificationType: type,
-    });
-
-    let totalSent = 0;
-    let totalFailed = 0;
-
-    await BatchProcessor.processInChunks(
-      userIds,
-      NOTIFICATION_BATCH_SIZE,
-      async (batchUserIds: number[]) => {
-        const result = await this.sendPushNotification({
-          type,
-          title: message.title,
-          content: message.content,
-          targetId,
           scheduleId: params.scheduleId,
           userIds: batchUserIds,
         });

--- a/src/notification/service/push-sender.service.ts
+++ b/src/notification/service/push-sender.service.ts
@@ -40,6 +40,7 @@ export class PushSenderService {
     title: string;
     content: string;
     targetId?: string;
+    scheduleId?: number;
     userIds: number[];
   }): Promise<{
     sent: number;

--- a/src/notification/strategies/interest-concert.strategy.ts
+++ b/src/notification/strategies/interest-concert.strategy.ts
@@ -21,7 +21,7 @@ export class InterestConcertStrategy implements NotificationStrategy {
     await BatchProcessor.processPaginated({
       batchSize: NOTIFICATION_BATCH_SIZE,
       fetchBatch: async (skip, take) => {
-        return await this.prisma.user.findMany({
+        return this.prisma.user.findMany({
           where: {
             userInterestConcerts: { none: {} },
             deletedAt: null,

--- a/src/notification/strategies/notification-strategy.service.ts
+++ b/src/notification/strategies/notification-strategy.service.ts
@@ -30,9 +30,12 @@ export class NotificationStrategyService {
       [NotificationType.CONCERT_INFO_UPDATE_TICKET, concertInfoUpdateStrategy],
       [NotificationType.INTEREST_CONCERT, interestConcertStrategy],
       [NotificationType.RECOMMEND, recommendationStrategy],
-      [NotificationType.TICKET_7D, ticketReminderStrategy],
-      [NotificationType.TICKET_1D, ticketReminderStrategy],
-      [NotificationType.TICKET_TODAY, ticketReminderStrategy],
+      [NotificationType.PRE_TICKETING_OPEN, ticketReminderStrategy],
+      [NotificationType.GENERAL_TICKETING_OPEN, ticketReminderStrategy],
+      [NotificationType.PRE_TICKETING_1D, ticketReminderStrategy],
+      [NotificationType.GENERAL_TICKETING_1D, ticketReminderStrategy],
+      [NotificationType.PRE_TICKETING_30MIN, ticketReminderStrategy],
+      [NotificationType.GENERAL_TICKETING_30MIN, ticketReminderStrategy],
     ]);
   }
 

--- a/src/notification/strategies/recommendation.strategy.ts
+++ b/src/notification/strategies/recommendation.strategy.ts
@@ -15,7 +15,7 @@ export class RecommendationStrategy implements NotificationStrategy {
 
   constructor(private readonly prisma: PrismaService) {}
 
-  async getTargetUserIds(params: NotificationTargetParams): Promise<number[]> {
+  async getTargetUserIds(_params: NotificationTargetParams): Promise<number[]> {
     const allUserIds: number[] = [];
 
     await BatchProcessor.processPaginated({
@@ -40,7 +40,7 @@ export class RecommendationStrategy implements NotificationStrategy {
   }
 
   async buildMessage(
-    params: NotificationTargetParams,
+    _params: NotificationTargetParams,
   ): Promise<NotificationMessage> {
     return {
       title: '취향 기반 콘서트 정보가 업데이트됐어요 🎵',

--- a/src/notification/strategies/ticket-reminder.strategy.ts
+++ b/src/notification/strategies/ticket-reminder.strategy.ts
@@ -8,11 +8,10 @@ import {
 } from './notification-strategy.interface';
 import { BatchProcessor } from 'src/common/utils/batch-processor.util';
 import { NOTIFICATION_BATCH_SIZE } from '../constants/notification.constants';
-import { formatHourAmPm } from 'src/common/utils/date.util';
 
 @Injectable()
 export class TicketReminderStrategy implements NotificationStrategy {
-  readonly type = NotificationType.TICKET_7D; // 대표 타입
+  readonly type = NotificationType.PRE_TICKETING_OPEN; // 대표 타입
 
   constructor(private readonly prisma: PrismaService) {}
 
@@ -32,7 +31,7 @@ export class TicketReminderStrategy implements NotificationStrategy {
     await BatchProcessor.processPaginated({
       batchSize: NOTIFICATION_BATCH_SIZE,
       fetchBatch: async (skip, take) => {
-        return await this.prisma.user.findMany({
+        return this.prisma.user.findMany({
           where: {
             userInterestConcerts: { some: { concertId: schedule.concertId } },
             deletedAt: null,
@@ -53,39 +52,51 @@ export class TicketReminderStrategy implements NotificationStrategy {
   async buildMessage(
     params: NotificationTargetParams,
   ): Promise<NotificationMessage> {
-    let { concertTitle, timeStr, daysUntil } = params;
+    const { concertTitle, notificationType } = params;
+    const title = concertTitle ?? '콘서트';
 
-    if (!concertTitle && params.concertId) {
-      const concert = await this.prisma.concert.findUnique({
-        where: { id: params.concertId },
-        select: { title: true },
-      });
-      concertTitle = concert?.title ?? '콘서트';
+    switch (notificationType) {
+      case NotificationType.PRE_TICKETING_OPEN:
+        return {
+          title: `선호 아티스트의 선예매 오픈🔥`,
+          content: `관심 콘서트로 선택하신 ${title}, 선예매 일정 소식이 도착했어요.`,
+        };
+
+      case NotificationType.GENERAL_TICKETING_OPEN:
+        return {
+          title: `선호 아티스트의 일반 예매 오픈🔥`,
+          content: `관심 콘서트로 선택하신 ${title}, 일반 예매 일정 소식이 도착했어요.`,
+        };
+
+      case NotificationType.PRE_TICKETING_1D:
+        return {
+          title: `콘서트 선예매 1일전이에요!`,
+          content: `관심 콘서트로 선택하신 ${title}, 내일 선예매가 시작돼요.`,
+        };
+
+      case NotificationType.PRE_TICKETING_30MIN:
+        return {
+          title: `콘서트 선예매 30분전이에요!`,
+          content: `관심 콘서트로 선택하신 ${title}, 30분 후 선예매가 시작해요.`,
+        };
+
+      case NotificationType.GENERAL_TICKETING_1D:
+        return {
+          title: `콘서트 일반 예매 1일전이에요!`,
+          content: `관심 콘서트로 선택하신 ${title}, 내일 일반 예매가 시작돼요.`,
+        };
+
+      case NotificationType.GENERAL_TICKETING_30MIN:
+        return {
+          title: `콘서트 일반 예매 30분전이에요!`,
+          content: `관심 콘서트로 선택하신 ${title}, 30분 후 일반 예매가 시작해요.`,
+        };
+
+      default:
+        return {
+          title: `선호 아티스트의 선예매 오픈🔥`,
+          content: `관심 콘서트로 선택하신 ${title}, 선예매 일정 소식이 도착했어요.`,
+        };
     }
-
-    if (daysUntil === undefined && params.notificationType) {
-      if (params.notificationType === NotificationType.TICKET_TODAY) {
-        daysUntil = 0;
-        timeStr = timeStr ?? '20시';
-      } else if (params.notificationType === NotificationType.TICKET_1D) {
-        daysUntil = 1;
-      } else {
-        daysUntil = 7;
-      }
-    } else {
-      daysUntil = daysUntil ?? 7;
-    }
-
-    if (daysUntil === 0) {
-      return {
-        title: `오늘 ${formatHourAmPm(timeStr ?? '')} 예매가 시작이에요`,
-        content: `관심 콘서트 '${concertTitle}', 오늘 ${formatHourAmPm(timeStr ?? '')} 예매가 시작돼요.`,
-      };
-    }
-
-    return {
-      title: `띵동! ${daysUntil}일 뒤 예매가 시작돼요`,
-      content: `관심 콘서트 '${concertTitle}', 예매 일정이 다가왔어요.`,
-    };
   }
 }

--- a/src/notification/strategies/ticket-reminder.strategy.ts
+++ b/src/notification/strategies/ticket-reminder.strategy.ts
@@ -93,10 +93,9 @@ export class TicketReminderStrategy implements NotificationStrategy {
         };
 
       default:
-        return {
-          title: `선호 아티스트의 선예매 오픈🔥`,
-          content: `관심 콘서트로 선택하신 ${title}, 선예매 일정 소식이 도착했어요.`,
-        };
+        throw new Error(
+          `Unsupported notificationType for TicketReminderStrategy: ${notificationType}`,
+        );
     }
   }
 }

--- a/src/notification/test/notification-list.spec.ts
+++ b/src/notification/test/notification-list.spec.ts
@@ -16,9 +16,9 @@ describe('NotificationService - 알림 목록', () => {
     {
       id: 3,
       userId: 1,
-      type: NotificationType.TICKET_7D,
+      type: NotificationType.PRE_TICKETING_OPEN,
       title: '예매 일정',
-      content: '7일 뒤 예매 시작',
+      content: '선예매 시작',
       targetId: '123',
       isRead: false,
       createdAt: '2026.01.20 10:00',

--- a/src/notification/test/notification-send.integration.spec.ts
+++ b/src/notification/test/notification-send.integration.spec.ts
@@ -109,18 +109,19 @@ describe('Notification send integration (FCM mock)', () => {
     mockHistoryService.createNotificationHistories.mockResolvedValue(undefined);
 
     await service.sendPushNotification({
-      type: NotificationType.TICKET_7D,
-      title: '띵동! 7일 뒤 예매가 시작돼요',
-      content: "관심 콘서트 '테스트콘서트', 예매 일정이 다가왔어요.",
+      type: NotificationType.PRE_TICKETING_OPEN,
+      title: '선호 아티스트의 선예매 오픈🔥',
+      content:
+        "관심 콘서트로 선택하신 '테스트콘서트', 선예매 일정 소식이 도착했어요.",
       targetId: '100',
       userIds: [1],
     });
 
     expect(mockSendEachForMulticast).toHaveBeenCalledTimes(1);
     const [message] = mockSendEachForMulticast.mock.calls[0];
-    expect(message.notification?.title).toBe('띵동! 7일 뒤 예매가 시작돼요');
+    expect(message.notification?.title).toBe('선호 아티스트의 선예매 오픈🔥');
     expect(message.notification?.body).toContain('관심 콘서트');
-    expect(message.data?.notificationType).toBe('TICKET_7D');
+    expect(message.data?.notificationType).toBe('PRE_TICKETING_OPEN');
     expect(message.data?.targetId).toBe('100');
     expect(message.tokens).toEqual(['test-fcm-token-1']);
   });

--- a/src/notification/test/ticket-reminder.scheduler.spec.ts
+++ b/src/notification/test/ticket-reminder.scheduler.spec.ts
@@ -16,7 +16,7 @@ describe('TicketingReminderScheduler', () => {
   };
 
   const mockNotificationService = {
-    sendTicketReminderNotification: jest
+    sendNotificationByStrategy: jest
       .fn()
       .mockResolvedValue({ sent: 1, failed: 0 }),
   };
@@ -70,7 +70,7 @@ describe('TicketingReminderScheduler', () => {
       await scheduler.oneDayBeforeNotification();
 
       expect(
-        notificationService.sendTicketReminderNotification,
+        notificationService.sendNotificationByStrategy,
       ).toHaveBeenCalledWith(
         NotificationType.PRE_TICKETING_1D,
         expect.objectContaining({
@@ -97,7 +97,7 @@ describe('TicketingReminderScheduler', () => {
       await scheduler.oneDayBeforeNotification();
 
       expect(
-        notificationService.sendTicketReminderNotification,
+        notificationService.sendNotificationByStrategy,
       ).toHaveBeenCalledWith(
         NotificationType.GENERAL_TICKETING_1D,
         expect.objectContaining({
@@ -132,7 +132,7 @@ describe('TicketingReminderScheduler', () => {
 
       expect(total).toBe(2);
       expect(
-        notificationService.sendTicketReminderNotification,
+        notificationService.sendNotificationByStrategy,
       ).toHaveBeenCalledTimes(2);
     });
 
@@ -178,7 +178,7 @@ describe('TicketingReminderScheduler', () => {
 
       expect(count).toBe(0);
       expect(
-        notificationService.sendTicketReminderNotification,
+        notificationService.sendNotificationByStrategy,
       ).not.toHaveBeenCalled();
     });
 
@@ -199,7 +199,7 @@ describe('TicketingReminderScheduler', () => {
 
       expect(count).toBe(1);
       expect(
-        notificationService.sendTicketReminderNotification,
+        notificationService.sendNotificationByStrategy,
       ).toHaveBeenCalledWith(
         NotificationType.PRE_TICKETING_30MIN,
         expect.objectContaining({
@@ -245,7 +245,7 @@ describe('TicketingReminderScheduler', () => {
 
       expect(count).toBe(0);
       expect(
-        notificationService.sendTicketReminderNotification,
+        notificationService.sendNotificationByStrategy,
       ).not.toHaveBeenCalled();
     });
 
@@ -266,7 +266,7 @@ describe('TicketingReminderScheduler', () => {
 
       expect(count).toBe(1);
       expect(
-        notificationService.sendTicketReminderNotification,
+        notificationService.sendNotificationByStrategy,
       ).toHaveBeenCalledWith(
         NotificationType.GENERAL_TICKETING_OPEN,
         expect.objectContaining({

--- a/src/notification/test/ticket-reminder.scheduler.spec.ts
+++ b/src/notification/test/ticket-reminder.scheduler.spec.ts
@@ -1,13 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { TicketingReminderScheduler } from '../scheduler/ticketing-reminder.scheduler';
 import { NotificationService } from '../service/notification.service';
+import { NotificationHistoryService } from '../service/notification-history.service';
 import { PrismaService } from 'prisma/prisma.service';
-import { NotificationType } from '@prisma/client';
+import { NotificationType, ScheduleType } from '@prisma/client';
 import { SchedulerMetricsService } from 'src/metrics/scheduler-metrics.service';
 
 describe('TicketingReminderScheduler', () => {
   let scheduler: TicketingReminderScheduler;
   let notificationService: NotificationService;
+  let historyService: NotificationHistoryService;
 
   const mockPrisma = {
     schedule: { findMany: jest.fn() },
@@ -19,12 +21,17 @@ describe('TicketingReminderScheduler', () => {
       .mockResolvedValue({ sent: 1, failed: 0 }),
   };
 
+  const mockHistoryService = {
+    existsByScheduleAndType: jest.fn(),
+  };
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TicketingReminderScheduler,
         { provide: PrismaService, useValue: mockPrisma },
         { provide: NotificationService, useValue: mockNotificationService },
+        { provide: NotificationHistoryService, useValue: mockHistoryService },
         {
           provide: SchedulerMetricsService,
           useValue: {
@@ -43,62 +50,277 @@ describe('TicketingReminderScheduler', () => {
 
     scheduler = module.get(TicketingReminderScheduler);
     notificationService = module.get(NotificationService);
+    historyService = module.get(NotificationHistoryService);
     jest.clearAllMocks();
   });
 
-  it('7일 후 TICKETING 스케줄 있으면 sendTicketReminderNotification 호출', async () => {
-    mockPrisma.schedule.findMany
-      .mockResolvedValueOnce([
-        {
-          id: 1,
-          concertId: 1,
-          concert: { id: 1, title: '테스트콘서트' },
-          scheduledAt: new Date(),
-        },
-      ])
-      .mockResolvedValue([]); // 1일, 오늘 스케줄은 없음
+  describe('oneDayBeforeNotification', () => {
+    it('PRE_TICKETING schedule 이 있으면 PRE_TICKETING_1D 로 발송', async () => {
+      mockPrisma.schedule.findMany
+        .mockResolvedValueOnce([
+          {
+            id: 10,
+            concertId: 1,
+            concert: { id: 1, title: '선예매콘서트' },
+            scheduledAt: new Date(),
+          },
+        ])
+        .mockResolvedValueOnce([]);
 
-    await scheduler.dailyTicketingNotifications();
+      await scheduler.oneDayBeforeNotification();
 
-    expect(
-      notificationService.sendTicketReminderNotification,
-    ).toHaveBeenCalledWith(
-      NotificationType.TICKET_7D,
-      expect.objectContaining({
-        scheduleId: 1,
-        concertTitle: '테스트콘서트',
-        daysUntil: 7,
-      }),
-      '1',
-    );
+      expect(
+        notificationService.sendTicketReminderNotification,
+      ).toHaveBeenCalledWith(
+        NotificationType.PRE_TICKETING_1D,
+        expect.objectContaining({
+          scheduleId: 10,
+          concertTitle: '선예매콘서트',
+          daysUntil: 1,
+        }),
+        '1',
+      );
+    });
+
+    it('GENERAL_TICKETING schedule 이 있으면 GENERAL_TICKETING_1D 로 발송', async () => {
+      mockPrisma.schedule.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            id: 20,
+            concertId: 2,
+            concert: { id: 2, title: '일반예매콘서트' },
+            scheduledAt: new Date(),
+          },
+        ]);
+
+      await scheduler.oneDayBeforeNotification();
+
+      expect(
+        notificationService.sendTicketReminderNotification,
+      ).toHaveBeenCalledWith(
+        NotificationType.GENERAL_TICKETING_1D,
+        expect.objectContaining({
+          scheduleId: 20,
+          concertTitle: '일반예매콘서트',
+          daysUntil: 1,
+        }),
+        '2',
+      );
+    });
+
+    it('PRE + GENERAL 둘 다 있으면 각각 발송 총합 반환', async () => {
+      mockPrisma.schedule.findMany
+        .mockResolvedValueOnce([
+          {
+            id: 10,
+            concertId: 1,
+            concert: { id: 1, title: '선' },
+            scheduledAt: new Date(),
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            id: 20,
+            concertId: 2,
+            concert: { id: 2, title: '일반' },
+            scheduledAt: new Date(),
+          },
+        ]);
+
+      const total = await scheduler.oneDayBeforeNotification();
+
+      expect(total).toBe(2);
+      expect(
+        notificationService.sendTicketReminderNotification,
+      ).toHaveBeenCalledTimes(2);
+    });
+
+    it('ScheduleType 으로 쿼리 필터링한다 (CONCERT 아님)', async () => {
+      mockPrisma.schedule.findMany.mockResolvedValue([]);
+
+      await scheduler.oneDayBeforeNotification();
+
+      expect(mockPrisma.schedule.findMany).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          where: expect.objectContaining({
+            type: ScheduleType.PRE_TICKETING,
+          }),
+        }),
+      );
+      expect(mockPrisma.schedule.findMany).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          where: expect.objectContaining({
+            type: ScheduleType.GENERAL_TICKETING,
+          }),
+        }),
+      );
+    });
   });
 
-  it('당일 TICKETING 스케줄 있으면 sendTicketReminderNotification 호출 (TICKET_TODAY)', async () => {
-    const todayScheduleTime = new Date('2025-01-23T11:00:00Z');
-    mockPrisma.schedule.findMany
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        {
-          id: 2,
-          concertId: 2,
-          concert: { id: 2, title: '당일콘서트' },
-          scheduledAt: todayScheduleTime,
-        },
-      ]);
+  describe('thirtyMinBeforeNotifications', () => {
+    it('이미 발송된 schedule 은 건너뛴다 (dedup)', async () => {
+      mockPrisma.schedule.findMany
+        .mockResolvedValueOnce([
+          {
+            id: 100,
+            concertId: 5,
+            concert: { id: 5, title: '중복' },
+            scheduledAt: new Date(),
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      mockHistoryService.existsByScheduleAndType.mockResolvedValue(true);
 
-    await scheduler.dailyTicketingNotifications();
+      const count = await scheduler.thirtyMinBeforeNotifications();
 
-    expect(
-      notificationService.sendTicketReminderNotification,
-    ).toHaveBeenCalledWith(
-      NotificationType.TICKET_TODAY,
-      expect.objectContaining({
-        scheduleId: 2,
-        concertTitle: '당일콘서트',
-        daysUntil: 0,
-      }),
-      '2',
-    );
+      expect(count).toBe(0);
+      expect(
+        notificationService.sendTicketReminderNotification,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('발송 이력 없으면 PRE_TICKETING_30MIN 으로 발송', async () => {
+      mockPrisma.schedule.findMany
+        .mockResolvedValueOnce([
+          {
+            id: 101,
+            concertId: 6,
+            concert: { id: 6, title: '신규' },
+            scheduledAt: new Date(),
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      mockHistoryService.existsByScheduleAndType.mockResolvedValue(false);
+
+      const count = await scheduler.thirtyMinBeforeNotifications();
+
+      expect(count).toBe(1);
+      expect(
+        notificationService.sendTicketReminderNotification,
+      ).toHaveBeenCalledWith(
+        NotificationType.PRE_TICKETING_30MIN,
+        expect.objectContaining({
+          scheduleId: 101,
+          concertTitle: '신규',
+          daysUntil: 0,
+        }),
+        '6',
+      );
+    });
+
+    it('29~31분 윈도우로 조회한다', async () => {
+      mockPrisma.schedule.findMany.mockResolvedValue([]);
+
+      const before = Date.now();
+      await scheduler.thirtyMinBeforeNotifications();
+
+      const firstCallWhere =
+        mockPrisma.schedule.findMany.mock.calls[0][0].where;
+      const { gte, lte } = firstCallWhere.scheduledAt;
+
+      // 29분 ~ 31분 윈도우 검증 (실행 시간 오차 고려)
+      expect(gte.getTime()).toBeGreaterThanOrEqual(before + 29 * 60 * 1000);
+      expect(lte.getTime()).toBeLessThanOrEqual(before + 31 * 60 * 1000 + 1000);
+    });
+  });
+
+  describe('openTimeNotifications', () => {
+    it('이미 발송된 schedule 은 건너뛴다 (dedup)', async () => {
+      mockPrisma.schedule.findMany
+        .mockResolvedValueOnce([
+          {
+            id: 200,
+            concertId: 9,
+            concert: { id: 9, title: '오픈중복' },
+            scheduledAt: new Date(),
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      mockHistoryService.existsByScheduleAndType.mockResolvedValue(true);
+
+      const count = await scheduler.openTimeNotifications();
+
+      expect(count).toBe(0);
+      expect(
+        notificationService.sendTicketReminderNotification,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('발송 이력 없으면 GENERAL_TICKETING_OPEN 으로 발송', async () => {
+      mockPrisma.schedule.findMany
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            id: 201,
+            concertId: 10,
+            concert: { id: 10, title: '오픈신규' },
+            scheduledAt: new Date(),
+          },
+        ]);
+      mockHistoryService.existsByScheduleAndType.mockResolvedValue(false);
+
+      const count = await scheduler.openTimeNotifications();
+
+      expect(count).toBe(1);
+      expect(
+        notificationService.sendTicketReminderNotification,
+      ).toHaveBeenCalledWith(
+        NotificationType.GENERAL_TICKETING_OPEN,
+        expect.objectContaining({
+          scheduleId: 201,
+          concertTitle: '오픈신규',
+          daysUntil: 0,
+        }),
+        '10',
+      );
+    });
+
+    it('과거 5분 ~ 현재 윈도우로 조회한다', async () => {
+      mockPrisma.schedule.findMany.mockResolvedValue([]);
+
+      const before = Date.now();
+      await scheduler.openTimeNotifications();
+
+      const firstCallWhere =
+        mockPrisma.schedule.findMany.mock.calls[0][0].where;
+      const { gte, lte } = firstCallWhere.scheduledAt;
+
+      expect(gte.getTime()).toBeGreaterThanOrEqual(before - 5 * 60 * 1000);
+      expect(lte.getTime()).toBeLessThanOrEqual(before + 1000);
+    });
+
+    it('dedup 체크를 각 schedule 마다 호출', async () => {
+      mockPrisma.schedule.findMany
+        .mockResolvedValueOnce([
+          {
+            id: 301,
+            concertId: 11,
+            concert: { id: 11, title: 'a' },
+            scheduledAt: new Date(),
+          },
+          {
+            id: 302,
+            concertId: 12,
+            concert: { id: 12, title: 'b' },
+            scheduledAt: new Date(),
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      mockHistoryService.existsByScheduleAndType.mockResolvedValue(false);
+
+      await scheduler.openTimeNotifications();
+
+      expect(historyService.existsByScheduleAndType).toHaveBeenCalledWith(
+        301,
+        NotificationType.PRE_TICKETING_OPEN,
+      );
+      expect(historyService.existsByScheduleAndType).toHaveBeenCalledWith(
+        302,
+        NotificationType.PRE_TICKETING_OPEN,
+      );
+    });
   });
 });

--- a/src/notification/test/ticket-reminder.strategy.spec.ts
+++ b/src/notification/test/ticket-reminder.strategy.spec.ts
@@ -1,0 +1,84 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { NotificationType } from '@prisma/client';
+import { PrismaService } from 'prisma/prisma.service';
+import { TicketReminderStrategy } from '../strategies/ticket-reminder.strategy';
+
+describe('TicketReminderStrategy.buildMessage', () => {
+  let strategy: TicketReminderStrategy;
+
+  const mockPrisma = {
+    schedule: { findUnique: jest.fn() },
+    user: { findMany: jest.fn() },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TicketReminderStrategy,
+        { provide: PrismaService, useValue: mockPrisma },
+      ],
+    }).compile();
+
+    strategy = module.get(TicketReminderStrategy);
+    jest.clearAllMocks();
+  });
+
+  const cases: Array<{ type: NotificationType; expectTitleIncludes: string }> =
+    [
+      {
+        type: NotificationType.PRE_TICKETING_OPEN,
+        expectTitleIncludes: '선예매 오픈',
+      },
+      {
+        type: NotificationType.GENERAL_TICKETING_OPEN,
+        expectTitleIncludes: '일반 예매 오픈',
+      },
+      {
+        type: NotificationType.PRE_TICKETING_1D,
+        expectTitleIncludes: '선예매 1일전',
+      },
+      {
+        type: NotificationType.GENERAL_TICKETING_1D,
+        expectTitleIncludes: '일반 예매 1일전',
+      },
+      {
+        type: NotificationType.PRE_TICKETING_30MIN,
+        expectTitleIncludes: '선예매 30분전',
+      },
+      {
+        type: NotificationType.GENERAL_TICKETING_30MIN,
+        expectTitleIncludes: '일반 예매 30분전',
+      },
+    ];
+
+  it.each(cases)(
+    '$type 은 알맞은 제목/내용을 만든다',
+    async ({ type, expectTitleIncludes }) => {
+      const message = await strategy.buildMessage({
+        notificationType: type,
+        concertTitle: '테스트콘서트',
+        timeStr: '오후 8시',
+      });
+
+      expect(message.title).toContain(expectTitleIncludes);
+      expect(message.content).toContain('테스트콘서트');
+    },
+  );
+
+  it('concertTitle 이 없으면 기본값 "콘서트" 로 대체된다', async () => {
+    const message = await strategy.buildMessage({
+      notificationType: NotificationType.PRE_TICKETING_OPEN,
+    });
+
+    expect(message.content).toContain('콘서트');
+  });
+
+  it('notificationType 이 없으면 default 메시지 반환', async () => {
+    const message = await strategy.buildMessage({
+      concertTitle: '기본',
+    });
+
+    expect(message.title).toBeDefined();
+    expect(message.content).toBeDefined();
+  });
+});

--- a/src/notification/test/ticket-reminder.strategy.spec.ts
+++ b/src/notification/test/ticket-reminder.strategy.spec.ts
@@ -73,12 +73,11 @@ describe('TicketReminderStrategy.buildMessage', () => {
     expect(message.content).toContain('콘서트');
   });
 
-  it('notificationType 이 없으면 default 메시지 반환', async () => {
-    const message = await strategy.buildMessage({
-      concertTitle: '기본',
-    });
-
-    expect(message.title).toBeDefined();
-    expect(message.content).toBeDefined();
+  it('지원하지 않는 notificationType 이면 Error 를 던진다', async () => {
+    await expect(
+      strategy.buildMessage({
+        concertTitle: '기본',
+      }),
+    ).rejects.toThrow(/Unsupported notificationType/);
   });
 });


### PR DESCRIPTION
## #️⃣ Issue Number
> Closed #267 

## 📝 요약(Summary)
> 티켓팅 알림 6종 + scheduleId dedup, 레거시 타입 정리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- NotificationType에 선예매/일반예매 x 오픈/1일전/30분전 6종 추가
- 티켓팅 시간별 스케줄러 분리
- 전에 있던 티켓팅 시간 관련 컬럼 및 데이터 전부 제거 및 이번 추가된 enum값 추가
- test파일 전부 통과 
- test알림 관련해서는 기록보니까 3월 14일 마지막이라 이건 나중에 ios쪽에서 로그인해서 테스트하고 받아야할거 같아유

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
