### PR TITLE
♻️ Refactor: #271 필터에 따른 콘서트 탐색 기능 리팩토링

### DIFF
--- a/src/common/constants/api-prefix.ts
+++ b/src/common/constants/api-prefix.ts
@@ -1,1 +1,1 @@
-export const API_PREFIX = 'api/v5';
+export const API_PREFIX = 'api/v6';

--- a/src/common/enums/concert-sort.enum.ts
+++ b/src/common/enums/concert-sort.enum.ts
@@ -1,4 +1,4 @@
 export enum ConcertSort {
-  LATEST = 'LATEST', // 최신순
+  UPCOMING = 'LATEST', // 최신순
   ALPHABETICAL = 'ALPHABETICAL', // 가나다순 (A-Z 순)
 }

--- a/src/concert/dto/concert-response.dto.ts
+++ b/src/concert/dto/concert-response.dto.ts
@@ -2,19 +2,19 @@ import { Concert } from '@prisma/client';
 
 export class ConcertResponseDto {
   id: number;
-  code: string;
-  title: string;
+  code: string | null;
+  title: string | null;
   artist: string;
-  startDate: string;
-  endDate: string;
-  poster: string;
+  startDate: string | null;
+  endDate: string | null;
+  poster: string | null;
   status: Concert['status'];
-  daysLeft: number;
-  ticketSite: string;
-  ticketUrl: string;
-  venue: string;
+  daysLeft: number | null;
+  ticketSite: string | null;
+  ticketUrl: string | null;
+  venue: string | null;
   introduction: string;
-  label: string;
+  label: string | null;
 
   private static formatDate(date: string | null): string | null {
     return date ? date.replaceAll('-', '.') : null;

--- a/src/home/dto/home-section-response.dto.ts
+++ b/src/home/dto/home-section-response.dto.ts
@@ -1,12 +1,12 @@
 import { Concert, HomeConcertSection, HomeSection } from '@prisma/client';
-import { getConcertDaysLeft, getDaysUntil } from 'src/common/utils/date.util';
+import { getConcertDaysLeft } from 'src/common/utils/date.util';
 
 export class HomeSectionResponseDto {
   id: number;
   sectionTitle: string;
   sortedIndex: number;
-  concerts: (Concert & { sortedIndex: number })[];
-  daysLeft: number;
+  concerts: (Concert & { sortedIndex: number; daysLeft: number | null })[];
+
   constructor(
     section: HomeSection & {
       homeConcertSections: (HomeConcertSection & { concert: Concert })[];

--- a/src/search/dto/get-concert-search-results.dto.ts
+++ b/src/search/dto/get-concert-search-results.dto.ts
@@ -36,7 +36,8 @@ export class GetConcertSearchResultsDto {
   })
   @IsEnum(ConcertStatus, {
     each: true,
-    message: 'status는 ONGOING | UPCOMING | COMPLETED | ALL 중 하나여야 해요',
+    message:
+      'status는 ONGOING | UPCOMING | COMPLETED | CANCELED | ALL 중 하나여야 해요',
   })
   @IsOptional()
   @Transform(({ value }) => (Array.isArray(value) ? value : [value]))
@@ -66,12 +67,13 @@ export class GetConcertSearchResultsDto {
   keyword?: string;
 
   @ApiProperty({
-    description: '커서(startDate + id 또는 title + id)',
+    description: '커서(마지막 콘서트의 id)',
     required: false,
-    example: '{"value":"2025.06.20","id":1}',
+    example: 50,
   })
   @IsOptional()
   @IsString()
+  @Transform(({ value }) => (value ? Number(value) : undefined))
   cursor?: string;
 
   @ApiProperty({

--- a/src/search/dto/get-concert-search-results.dto.ts
+++ b/src/search/dto/get-concert-search-results.dto.ts
@@ -67,14 +67,14 @@ export class GetConcertSearchResultsDto {
   keyword?: string;
 
   @ApiProperty({
-    description: '커서(마지막 콘서트의 id)',
+    description: '커서 (마지막 콘서트 ID)',
     required: false,
-    example: 50,
+    example: 59,
   })
   @IsOptional()
-  @IsString()
-  @Transform(({ value }) => (value ? Number(value) : undefined))
-  cursor?: string;
+  @IsNumber()
+  @Min(1)
+  cursor?: number;
 
   @ApiProperty({
     description: '가져올 데이터 개수',

--- a/src/search/dto/search-section-response.dto.ts
+++ b/src/search/dto/search-section-response.dto.ts
@@ -1,12 +1,11 @@
 import { Concert, SearchConcertSection, SearchSection } from '@prisma/client';
-import { getConcertDaysLeft, getDaysUntil } from '../../common/utils/date.util';
+import { getConcertDaysLeft } from '../../common/utils/date.util';
 
 export class SearchSectionResponseDto {
   id: number;
   sectionTitle: string;
   sortedIndex: number;
-  concerts: (Concert & { sortedIndex: number })[];
-  daysLeft: number;
+  concerts: (Concert & { sortedIndex: number; daysLeft: number | null })[];
 
   constructor(
     section: SearchSection & {

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -76,13 +76,29 @@ export class SearchService {
   async getConcertSearchResults(query: GetConcertSearchResultsDto) {
     const { genre, status, sort, keyword, cursor, size } = query;
 
-    // cursor 파싱
-    let parsedCursor: { value: string; id: number } | undefined;
+    // 1, cursor -> 해당 콘서트 조회해서 composite cursor 구성
+    let cursorObj;
     if (cursor) {
-      try {
-        parsedCursor = JSON.parse(cursor);
-      } catch (e) {
+      const cursorConcert = await this.prismaService.concert.findUnique({
+        where: { id: cursor },
+        select: { id: true, startDate: true, title: true },
+      });
+
+      if (!cursorConcert) {
         throw new BadRequestException(ErrorCode.INVALID_CURSOR_FORMAT);
+      }
+
+      if (sort === ConcertSort.ALPHABETICAL) {
+        cursorObj = {
+          title_id: { title: cursorConcert.title, id: cursorConcert.id },
+        };
+      } else {
+        cursorObj = {
+          startDate_id: {
+            startDate: cursorConcert.startDate,
+            id: cursorConcert.id,
+          },
+        };
       }
     }
 
@@ -96,26 +112,16 @@ export class SearchService {
         }
       : undefined;
 
+    // 3. 정렬 조건
     let orderBy;
-    let cursorObj;
-
-    // 정렬 조건에 따른 orderBy 및 cursor 설정
-    if (sort === undefined || sort === ConcertSort.LATEST) {
-      orderBy = [{ startDate: 'desc' }, { id: 'asc' }];
-      if (parsedCursor) {
-        cursorObj = {
-          startDate_id: { startDate: parsedCursor.value, id: parsedCursor.id },
-        };
-      }
-    } else {
+    if (sort === ConcertSort.ALPHABETICAL) {
       orderBy = [{ title: 'asc' }, { id: 'asc' }];
-      if (parsedCursor) {
-        cursorObj = {
-          title_id: { title: parsedCursor.value, id: parsedCursor.id },
-        };
-      }
+    } else {
+      // 공연 날짜 가까운 순
+      orderBy = [{ startDate: 'asc' }, { id: 'asc' }];
     }
 
+    // 4. WHERE 조건 조합
     const where = {
       AND: [],
     };
@@ -139,28 +145,26 @@ export class SearchService {
       where.AND.push(keywordCondition);
     }
 
-    const searchResults = await this.prismaService.concert.findMany({
-      where: where.AND.length > 0 ? where : undefined,
-      orderBy,
-      skip: parsedCursor ? 1 : 0,
-      cursor: cursorObj,
-      take: size,
-    });
+    // 5. 쿼리 실행
+    const whereClause = where.AND.length > 0 ? where : undefined;
+
+    const [searchResults, totalCount] =
+      await this.prismaService.concert.findMany({
+        where: whereClause,
+        orderBy,
+        skip: cursor ? 1 : 0,
+        cursor: cursorObj,
+        take: size,
+      });
 
     // 전체 개수
     const totalCount = await this.prismaService.concert.count({
       where: where.AND.length > 0 ? where : undefined,
     });
 
-    // 다음 커서 계산
+    // 6. 다음 커서 계산
     const last = searchResults[searchResults.length - 1];
-    let nextCursor;
-    if (last) {
-      nextCursor =
-        sort === ConcertSort.LATEST
-          ? { value: last.startDate, id: last.id }
-          : { value: last.title, id: last.id };
-    }
+    const nextCursor = last ? last.id : null;
 
     return {
       data: searchResults.map(

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -6,10 +6,10 @@ import { ConcertSort } from '../common/enums/concert-sort.enum';
 import { ConcertGenre } from '../common/enums/concert-genre.enum';
 import { ConcertStatus } from '../common/enums/concert-status.enum';
 import { ConcertResponseDto } from '../concert/dto/concert-response.dto';
-import { getDaysUntil } from '../common/utils/date.util';
+import { getConcertDaysLeft } from '../common/utils/date.util';
 import { GenreType } from '@prisma/client';
 import { GetConcertSearchResultsDto } from './dto/get-concert-search-results.dto';
-import { BadRequestException } from '../common/exceptions/business.exception';
+import { NotFoundException } from '../common/exceptions/business.exception';
 import { ErrorCode } from '../common/enums/error-code.enum';
 import { RepresentativeArtistResponseDto } from './dto/representative-artist-response.dto';
 
@@ -76,102 +76,91 @@ export class SearchService {
   async getConcertSearchResults(query: GetConcertSearchResultsDto) {
     const { genre, status, sort, keyword, cursor, size } = query;
 
-    // 1, cursor -> 해당 콘서트 조회해서 composite cursor 구성
+    const hasAll = status?.includes(ConcertStatus.ALL) ?? false;
+
+    // 1. cursor 콘서트 조회 -> composite cursor 구성
+    const cursorConcert = cursor
+      ? await this.prismaService.concert.findUnique({
+          where: { id: cursor },
+          select: { id: true, startDate: true, title: true },
+        })
+      : null;
+    if (cursor && !cursorConcert) {
+      throw new NotFoundException(ErrorCode.CONCERT_NOT_FOUND);
+    }
+
+    // 2. 정렬 조건 (가나다순 또는 공연 날짜순)
+    const orderBy =
+      sort === ConcertSort.ALPHABETICAL
+        ? [{ title: 'asc' as const }, { id: 'asc' as const }]
+        : [{ startDate: 'asc' as const }, { id: 'asc' as const }];
+
+    // 3. composite cursor 구성
     let cursorObj;
-    if (cursor) {
-      const cursorConcert = await this.prismaService.concert.findUnique({
-        where: { id: cursor },
-        select: { id: true, startDate: true, title: true },
-      });
-
-      if (!cursorConcert) {
-        throw new BadRequestException(ErrorCode.INVALID_CURSOR_FORMAT);
-      }
-
-      if (sort === ConcertSort.ALPHABETICAL) {
-        cursorObj = {
-          title_id: { title: cursorConcert.title, id: cursorConcert.id },
-        };
-      } else {
-        cursorObj = {
-          startDate_id: {
-            startDate: cursorConcert.startDate,
-            id: cursorConcert.id,
-          },
-        };
-      }
+    if (cursorConcert) {
+      cursorObj =
+        sort === ConcertSort.ALPHABETICAL
+          ? {
+              title_id: { title: cursorConcert.title, id: cursorConcert.id },
+            }
+          : {
+              startDate_id: {
+                startDate: cursorConcert.startDate,
+                id: cursorConcert.id,
+              },
+            };
     }
 
-    // 키워드 검색 조건
-    const keywordCondition = keyword
-      ? {
-          OR: [
-            { title: { contains: keyword } },
-            { artist: { contains: keyword } },
-          ],
-        }
-      : undefined;
+    // 4. WHERE 조건
+    const where = { AND: [] };
 
-    // 3. 정렬 조건
-    let orderBy;
-    if (sort === ConcertSort.ALPHABETICAL) {
-      orderBy = [{ title: 'asc' }, { id: 'asc' }];
-    } else {
-      // 공연 날짜 가까운 순
-      orderBy = [{ startDate: 'asc' }, { id: 'asc' }];
-    }
-
-    // 4. WHERE 조건 조합
-    const where = {
-      AND: [],
-    };
-
-    if (status && !status.includes(ConcertStatus.ALL)) {
+    if (status && !hasAll) {
       where.AND.push({ status: { in: status } });
+    } else {
+      // ALL 또는 미입력 시 CANCELED 제외
+      where.AND.push({ status: { not: ConcertStatus.CANCELED } });
     }
 
-    // genre 조건 (Prisma enum 변환)
     if (genre && !genre.includes(ConcertGenre.ALL)) {
       const prismaGenres = genre.map(
         (g) => GenreType[g as keyof typeof GenreType],
       );
-
       where.AND.push({
         concertGenre: { some: { genre: { name: { in: prismaGenres } } } },
       });
     }
 
     if (keyword) {
-      where.AND.push(keywordCondition);
+      where.AND.push({
+        OR: [
+          { title: { contains: keyword } },
+          { artist: { contains: keyword } },
+        ],
+      });
     }
 
     // 5. 쿼리 실행
-    const whereClause = where.AND.length > 0 ? where : undefined;
-
-    const [searchResults, totalCount] =
-      await this.prismaService.concert.findMany({
-        where: whereClause,
+    const [searchResults, totalCount] = await this.prismaService.$transaction([
+      this.prismaService.concert.findMany({
+        where,
         orderBy,
         skip: cursor ? 1 : 0,
         cursor: cursorObj,
         take: size,
-      });
+      }),
+      this.prismaService.concert.count({ where }),
+    ]);
 
-    // 전체 개수
-    const totalCount = await this.prismaService.concert.count({
-      where: where.AND.length > 0 ? where : undefined,
-    });
-
-    // 6. 다음 커서 계산
     const last = searchResults[searchResults.length - 1];
-    const nextCursor = last ? last.id : null;
-
     return {
       data: searchResults.map(
         (concert) =>
-          new ConcertResponseDto(concert, getDaysUntil(concert.startDate)),
+          new ConcertResponseDto(
+            concert,
+            getConcertDaysLeft(concert.startDate, concert.endDate),
+          ),
       ),
-      cursor: nextCursor,
+      cursor: last ? last.id : null,
       totalCount,
     };
   }

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -74,64 +74,58 @@ export class SearchService {
 
   //필터에 따른 검색 결과 콘서트 목록 조회
   async getConcertSearchResults(query: GetConcertSearchResultsDto) {
-    const { genre, status, sort, keyword, cursor, size } = query;
+    const { genre, status, sort, keyword, cursor, size = 20 } = query;
 
     const hasAll = status?.includes(ConcertStatus.ALL) ?? false;
 
-    // 1. cursor 콘서트 조회 -> composite cursor 구성
+    // 1. cursor 콘서트 조회 (status까지 가져와서 phase 판단에 사용)
     const cursorConcert = cursor
       ? await this.prismaService.concert.findUnique({
           where: { id: cursor },
-          select: { id: true, startDate: true, title: true },
+          select: { id: true, startDate: true, title: true, status: true },
         })
       : null;
     if (cursor && !cursorConcert) {
       throw new NotFoundException(ErrorCode.CONCERT_NOT_FOUND);
     }
 
-    // 2. 정렬 조건 (가나다순 또는 공연 날짜순)
+    // 2. 선택 상태 분류 (CANCELED는 항상 뒤로 보내야 하므로 분리)
+    const explicitStatuses =
+      status && !hasAll
+        ? status.filter((s) => s !== ConcertStatus.ALL)
+        : null;
+    const wantsCancelled = explicitStatuses
+      ? explicitStatuses.includes(ConcertStatus.CANCELED)
+      : false;
+    const nonCancelledStatuses = explicitStatuses
+      ? explicitStatuses.filter((s) => s !== ConcertStatus.CANCELED)
+      : null;
+    const wantsNonCancelled =
+      nonCancelledStatuses === null || nonCancelledStatuses.length > 0;
+
+    // 3. 정렬 조건
     const orderBy =
       sort === ConcertSort.ALPHABETICAL
         ? [{ title: 'asc' as const }, { id: 'asc' as const }]
         : [{ startDate: 'asc' as const }, { id: 'asc' as const }];
 
-    // 3. composite cursor 구성
-    let cursorObj;
-    if (cursorConcert) {
-      cursorObj =
-        sort === ConcertSort.ALPHABETICAL
-          ? {
-              title_id: { title: cursorConcert.title, id: cursorConcert.id },
-            }
-          : {
-              startDate_id: {
-                startDate: cursorConcert.startDate,
-                id: cursorConcert.id,
-              },
-            };
-    }
+    const buildCursorObj = (c: typeof cursorConcert) =>
+      sort === ConcertSort.ALPHABETICAL
+        ? { title_id: { title: c.title, id: c.id } }
+        : { startDate_id: { startDate: c.startDate, id: c.id } };
 
-    // 4. WHERE 조건
-    const where = { AND: [] };
-
-    if (status && !hasAll) {
-      where.AND.push({ status: { in: status } });
-    } else {
-      // ALL 또는 미입력 시 CANCELED 제외
-      where.AND.push({ status: { not: ConcertStatus.CANCELED } });
-    }
-
+    // 4. 공통 필터 (장르 + 키워드)
+    const baseAnd: any[] = [];
     if (genre && !genre.includes(ConcertGenre.ALL)) {
       const prismaGenres = genre.map(
         (g) => GenreType[g as keyof typeof GenreType],
       );
-      where.AND.push({
+      baseAnd.push({
         concertGenre: { some: { genre: { name: { in: prismaGenres } } } },
       });
     }
-
     if (keyword) {
-      where.AND.push({
+      baseAnd.push({
         OR: [
           { title: { contains: keyword } },
           { artist: { contains: keyword } },
@@ -139,21 +133,53 @@ export class SearchService {
       });
     }
 
-    // 5. 쿼리 실행
-    const [searchResults, totalCount] = await Promise.all([
-      this.prismaService.concert.findMany({
-        where,
-        orderBy,
-        skip: cursor ? 1 : 0,
-        cursor: cursorObj,
-        take: size,
-      }),
-      this.prismaService.concert.count({ where }),
-    ]);
+    // 5. Phase 결정: cursor가 CANCELED면 phase 2부터, 아니면 phase 1부터
+    const inPhase2 = cursorConcert?.status === ConcertStatus.CANCELED;
 
-    const last = searchResults[searchResults.length - 1];
+    // Phase 1: non-CANCELED
+    let phase1: Awaited<
+      ReturnType<typeof this.prismaService.concert.findMany>
+    > = [];
+    if (wantsNonCancelled && !inPhase2) {
+      const phase1Status = nonCancelledStatuses
+        ? { in: nonCancelledStatuses }
+        : { not: ConcertStatus.CANCELED };
+      phase1 = await this.prismaService.concert.findMany({
+        where: { AND: [...baseAnd, { status: phase1Status }] },
+        orderBy,
+        cursor: cursorConcert ? buildCursorObj(cursorConcert) : undefined,
+        skip: cursorConcert ? 1 : 0,
+        take: size,
+      });
+    }
+
+    // Phase 2: CANCELED (남은 자리만큼만 채움)
+    const remaining = size - phase1.length;
+    let phase2: typeof phase1 = [];
+    if (wantsCancelled && remaining > 0) {
+      const useCursor = inPhase2 && cursorConcert;
+      phase2 = await this.prismaService.concert.findMany({
+        where: { AND: [...baseAnd, { status: ConcertStatus.CANCELED }] },
+        orderBy,
+        cursor: useCursor ? buildCursorObj(cursorConcert) : undefined,
+        skip: useCursor ? 1 : 0,
+        take: remaining,
+      });
+    }
+
+    const merged = [...phase1, ...phase2];
+
+    // 6. 전체 count
+    const countStatusCondition = explicitStatuses
+      ? { status: { in: explicitStatuses } }
+      : { status: { not: ConcertStatus.CANCELED } };
+    const totalCount = await this.prismaService.concert.count({
+      where: { AND: [...baseAnd, countStatusCondition] },
+    });
+
+    const last = merged[merged.length - 1];
     return {
-      data: searchResults.map(
+      data: merged.map(
         (concert) =>
           new ConcertResponseDto(
             concert,

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -140,7 +140,7 @@ export class SearchService {
     }
 
     // 5. 쿼리 실행
-    const [searchResults, totalCount] = await this.prismaService.$transaction([
+    const [searchResults, totalCount] = await Promise.all([
       this.prismaService.concert.findMany({
         where,
         orderBy,

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -7,7 +7,7 @@ import { ConcertGenre } from '../common/enums/concert-genre.enum';
 import { ConcertStatus } from '../common/enums/concert-status.enum';
 import { ConcertResponseDto } from '../concert/dto/concert-response.dto';
 import { getConcertDaysLeft } from '../common/utils/date.util';
-import { GenreType } from '@prisma/client';
+import { GenreType, Prisma } from '@prisma/client';
 import { GetConcertSearchResultsDto } from './dto/get-concert-search-results.dto';
 import { NotFoundException } from '../common/exceptions/business.exception';
 import { ErrorCode } from '../common/enums/error-code.enum';
@@ -91,9 +91,7 @@ export class SearchService {
 
     // 2. 선택 상태 분류 (CANCELED는 항상 뒤로 보내야 하므로 분리)
     const explicitStatuses =
-      status && !hasAll
-        ? status.filter((s) => s !== ConcertStatus.ALL)
-        : null;
+      status && !hasAll ? status.filter((s) => s !== ConcertStatus.ALL) : null;
     const wantsCancelled = explicitStatuses
       ? explicitStatuses.includes(ConcertStatus.CANCELED)
       : false;
@@ -115,7 +113,7 @@ export class SearchService {
         : { startDate_id: { startDate: c.startDate, id: c.id } };
 
     // 4. 공통 필터 (장르 + 키워드)
-    const baseAnd: any[] = [];
+    const baseAnd: Prisma.ConcertWhereInput[] = [];
     if (genre && !genre.includes(ConcertGenre.ALL)) {
       const prismaGenres = genre.map(
         (g) => GenreType[g as keyof typeof GenreType],
@@ -136,46 +134,71 @@ export class SearchService {
     // 5. Phase 결정: cursor가 CANCELED면 phase 2부터, 아니면 phase 1부터
     const inPhase2 = cursorConcert?.status === ConcertStatus.CANCELED;
 
-    // Phase 1: non-CANCELED
-    let phase1: Awaited<
-      ReturnType<typeof this.prismaService.concert.findMany>
-    > = [];
-    if (wantsNonCancelled && !inPhase2) {
-      const phase1Status = nonCancelledStatuses
-        ? { in: nonCancelledStatuses }
-        : { not: ConcertStatus.CANCELED };
-      phase1 = await this.prismaService.concert.findMany({
-        where: { AND: [...baseAnd, { status: phase1Status }] },
-        orderBy,
-        cursor: cursorConcert ? buildCursorObj(cursorConcert) : undefined,
-        skip: cursorConcert ? 1 : 0,
-        take: size,
-      });
-    }
+    // 6. count용 status 조건
+    const countStatusCondition: Prisma.ConcertWhereInput = explicitStatuses
+      ? {
+          status: {
+            in: explicitStatuses as Prisma.EnumConcertStatusFilter['in'],
+          },
+        }
+      : {
+          status: {
+            not: ConcertStatus.CANCELED as Prisma.ConcertWhereInput['status'],
+          },
+        };
 
-    // Phase 2: CANCELED (남은 자리만큼만 채움)
-    const remaining = size - phase1.length;
-    let phase2: typeof phase1 = [];
-    if (wantsCancelled && remaining > 0) {
-      const useCursor = inPhase2 && cursorConcert;
-      phase2 = await this.prismaService.concert.findMany({
-        where: { AND: [...baseAnd, { status: ConcertStatus.CANCELED }] },
-        orderBy,
-        cursor: useCursor ? buildCursorObj(cursorConcert) : undefined,
-        skip: useCursor ? 1 : 0,
-        take: remaining,
-      });
-    }
+    // 7. 단일 트랜잭션 안에서 phase 1 → phase 2 → count 순차 실행 (스냅샷 일관성 보장)
+    const { merged, totalCount } = await this.prismaService.$transaction(
+      async (tx) => {
+        // Phase 1: non-CANCELED
+        let phase1: Awaited<ReturnType<typeof tx.concert.findMany>> = [];
+        if (wantsNonCancelled && !inPhase2) {
+          const phase1Status: Prisma.EnumConcertStatusFilter =
+            nonCancelledStatuses
+              ? {
+                  in: nonCancelledStatuses as Prisma.EnumConcertStatusFilter['in'],
+                }
+              : {
+                  not: ConcertStatus.CANCELED as Prisma.EnumConcertStatusFilter['not'],
+                };
+          phase1 = await tx.concert.findMany({
+            where: { AND: [...baseAnd, { status: phase1Status }] },
+            orderBy,
+            cursor: cursorConcert ? buildCursorObj(cursorConcert) : undefined,
+            skip: cursorConcert ? 1 : 0,
+            take: size,
+          });
+        }
 
-    const merged = [...phase1, ...phase2];
+        // Phase 2: CANCELED (남은 자리만큼만 채움)
+        const remaining = size - phase1.length;
+        let phase2: typeof phase1 = [];
+        if (wantsCancelled && remaining > 0) {
+          const useCursor = inPhase2 && cursorConcert;
+          phase2 = await tx.concert.findMany({
+            where: {
+              AND: [
+                ...baseAnd,
+                {
+                  status:
+                    ConcertStatus.CANCELED as Prisma.ConcertWhereInput['status'],
+                },
+              ],
+            },
+            orderBy,
+            cursor: useCursor ? buildCursorObj(cursorConcert) : undefined,
+            skip: useCursor ? 1 : 0,
+            take: remaining,
+          });
+        }
 
-    // 6. 전체 count
-    const countStatusCondition = explicitStatuses
-      ? { status: { in: explicitStatuses } }
-      : { status: { not: ConcertStatus.CANCELED } };
-    const totalCount = await this.prismaService.concert.count({
-      where: { AND: [...baseAnd, countStatusCondition] },
-    });
+        const totalCount = await tx.concert.count({
+          where: { AND: [...baseAnd, countStatusCondition] },
+        });
+
+        return { merged: [...phase1, ...phase2], totalCount };
+      },
+    );
 
     const last = merged[merged.length - 1];
     return {

--- a/src/user/dto/interest-concert-response.dto.ts
+++ b/src/user/dto/interest-concert-response.dto.ts
@@ -2,31 +2,31 @@ import { Concert } from '@prisma/client';
 
 export class InterestConcertResponseDto {
   id: number;
-  code: string;
-  title: string;
+  code: string | null;
+  title: string | null;
   artist: string;
-  startDate: string;
-  endDate: string;
-  poster: string;
+  startDate: string | null;
+  endDate: string | null;
+  poster: string | null;
   status: Concert['status'];
-  daysLeft: number;
-  ticketSite: string;
-  ticketUrl: string;
-  venue: string;
+  daysLeft: number | null;
+  ticketSite: string | null;
+  ticketUrl: string | null;
+  venue: string | null;
   introduction: string;
-  label: string;
-  preSaleDate: string;
-  generalSaleDate: string;
+  label: string | null;
+  preSaleDate: string | null;
+  generalSaleDate: string | null;
 
-  private static formatDate(date: string): string {
+  private static formatDate(date: string | null): string | null {
     return date ? date.replaceAll('-', '.') : null;
   }
 
   constructor(
     concert: Concert,
-    preSaleDate: string,
-    generalSaleDate: string,
-    daysLeft?: number,
+    preSaleDate: string | null,
+    generalSaleDate: string | null,
+    daysLeft?: number | null,
   ) {
     this.id = concert.id;
     this.code = concert.code;

--- a/src/user/user.service.spec.ts
+++ b/src/user/user.service.spec.ts
@@ -502,15 +502,15 @@ describe('UserService', () => {
 
         // Then
         expect(result).toEqual({ isInterested: true });
-        expect(mockPrismaService.userInterestConcert.findFirst).toHaveBeenCalledWith(
-          {
-            where: {
-              userId,
-              concertId,
-            },
-            select: { id: true },
+        expect(
+          mockPrismaService.userInterestConcert.findFirst,
+        ).toHaveBeenCalledWith({
+          where: {
+            userId,
+            concertId,
           },
-        );
+          select: { id: true },
+        });
       });
 
       it('관심 콘서트가 없으면 isInterested=false를 반환해야 함', async () => {


### PR DESCRIPTION
## #️⃣ Issue Number
> Closed #271 

## 📝 요약(Summary)
> 콘서트 필터(상태, 장르, 키워드) + 커서 id 일관화 + 정렬

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- cusror 콘서트의 status 조회 -> CANCELED는 phase 2부터 시작, 아니면 phase1부터
- CANCELED -> Phase 1: skip, Phase 2: CANCELED처리
- ONGOING -> Phase 1: ONGOING만, Phase2: skip
- [ONGOING, CANCELED]: ONGOING(앞), CANCELED(뒤) => 취소된것들은 전부 뒤로
- [ALL, CANCELED]: ALL이 우선시되서 Phase 1만 처리
- [ONGOING, COMPLETED]: 공연날짜 가까운순으로 처리(Phase1)

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
