### PR TITLE
🐛 fix: 콘서트 검색 NULL 정렬 + Artist unique 추가 + 테스트 보강

### DIFF
--- a/prisma/migrations/20260507135730_add_artist_unique/migration.sql
+++ b/prisma/migrations/20260507135730_add_artist_unique/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[artist]` on the table `artists` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX `artists_artist_key` ON `artists`(`artist`);

--- a/prisma/migrations/20260507224841_add_crawl_history_and_schedule_unique/migration.sql
+++ b/prisma/migrations/20260507224841_add_crawl_history_and_schedule_unique/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE `crawl_history` (
+    `id`              INTEGER      NOT NULL AUTO_INCREMENT,
+    `account`         VARCHAR(100) NOT NULL,
+    `last_crawled_at` DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `created_at`      DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updated_at`      DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `uk_account`(`account`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AlterTable
+ALTER TABLE `schedule`
+    ADD UNIQUE INDEX `uk_schedule`(`concert_id`, `scheduled_at`, `category`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,7 +46,7 @@ model Concert {
 
 model Artist {
   id           Int       @id @default(autoincrement())
-  artist       String    @db.VarChar(100)
+  artist       String    @unique @db.VarChar(100)
   category     String?   @db.VarChar(30)
   detail       String?   @db.Text
   instagramUrl String?   @map("instagram_url") @db.VarChar(2048)
@@ -112,6 +112,7 @@ model Schedule {
   type        ScheduleType?
   concert     Concert       @relation(fields: [concertId], references: [id])
 
+  @@unique([concertId, scheduledAt, category], map: "uk_schedule")
   @@map("schedule")
 }
 
@@ -212,7 +213,7 @@ model Banner {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
   content   String   @db.VarChar(100)
-  linkUrl  String?   @db.VarChar(2048) @map("link_url")
+  linkUrl   String?  @map("link_url") @db.VarChar(2048)
 
   @@map("banners")
 }
@@ -497,6 +498,16 @@ model Resignation {
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
   @@map("resignations")
+}
+
+model CrawlHistory {
+  id            Int      @id @default(autoincrement())
+  account       String   @unique(map: "uk_account") @db.VarChar(100)
+  lastCrawledAt DateTime @default(now()) @map("last_crawled_at") @db.DateTime(3)
+  createdAt     DateTime @default(now()) @map("created_at") @db.DateTime(3)
+  updatedAt     DateTime @default(now()) @updatedAt @map("updated_at") @db.DateTime(3)
+
+  @@map("crawl_history")
 }
 
 enum ConcertStatus {

--- a/src/artist/service/artist-matching.service.spec.ts
+++ b/src/artist/service/artist-matching.service.spec.ts
@@ -1,0 +1,147 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from 'prisma/prisma.service';
+import { ArtistMatchingService } from './artist-matching.service';
+
+describe('ArtistMatchingService', () => {
+  let service: ArtistMatchingService;
+  let mockPrismaService: any;
+
+  beforeEach(async () => {
+    mockPrismaService = {
+      representativeArtist: {
+        findMany: jest.fn(),
+      },
+      userArtist: {
+        findMany: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ArtistMatchingService,
+        { provide: PrismaService, useValue: mockPrismaService },
+      ],
+    }).compile();
+
+    service = module.get<ArtistMatchingService>(ArtistMatchingService);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('findMatchingRepresentativeArtistIds', () => {
+    it('정규화된 이름이 일치하는 아티스트 id 반환', async () => {
+      mockPrismaService.representativeArtist.findMany.mockResolvedValue([
+        { id: 1, artistName: 'NewJeans' },
+        { id: 2, artistName: 'IVE' },
+        { id: 3, artistName: 'aespa' },
+      ]);
+
+      const result =
+        await service.findMatchingRepresentativeArtistIds('NewJeans');
+
+      expect(result).toEqual([1]);
+    });
+
+    it('대소문자/공백 차이 무시하고 매칭', async () => {
+      mockPrismaService.representativeArtist.findMany.mockResolvedValue([
+        { id: 1, artistName: 'NewJeans' },
+        { id: 2, artistName: 'IVE' },
+      ]);
+
+      const result =
+        await service.findMatchingRepresentativeArtistIds('  newjeans  ');
+
+      expect(result).toEqual([1]);
+    });
+
+    it('이름 끝 괄호 블록 무시하고 매칭 (e.g. "IVE (아이브)" → "IVE")', async () => {
+      mockPrismaService.representativeArtist.findMany.mockResolvedValue([
+        { id: 1, artistName: 'IVE' },
+        { id: 2, artistName: 'aespa' },
+      ]);
+
+      const result =
+        await service.findMatchingRepresentativeArtistIds('IVE (아이브)');
+
+      expect(result).toEqual([1]);
+    });
+
+    it('일치하는 아티스트 없으면 빈 배열', async () => {
+      mockPrismaService.representativeArtist.findMany.mockResolvedValue([
+        { id: 1, artistName: 'NewJeans' },
+        { id: 2, artistName: 'IVE' },
+      ]);
+
+      const result =
+        await service.findMatchingRepresentativeArtistIds('Unknown');
+
+      expect(result).toEqual([]);
+    });
+
+    it('동일 정규화 결과인 아티스트 여러 명이면 모두 반환', async () => {
+      mockPrismaService.representativeArtist.findMany.mockResolvedValue([
+        { id: 1, artistName: 'IVE' },
+        { id: 2, artistName: 'IVE (아이브)' },
+        { id: 3, artistName: 'aespa' },
+      ]);
+
+      const result = await service.findMatchingRepresentativeArtistIds('IVE');
+
+      expect(result).toEqual([1, 2]);
+    });
+  });
+
+  describe('findUserIdsByArtistIds', () => {
+    it('빈 artistIds 입력 시 DB 조회 안 하고 빈 배열 반환', async () => {
+      const result = await service.findUserIdsByArtistIds([]);
+
+      expect(result).toEqual([]);
+      expect(mockPrismaService.userArtist.findMany).not.toHaveBeenCalled();
+    });
+
+    it('artistIds 에 매칭되는 userId 목록 반환', async () => {
+      mockPrismaService.userArtist.findMany.mockResolvedValue([
+        { userId: 10 },
+        { userId: 20 },
+        { userId: 30 },
+      ]);
+
+      const result = await service.findUserIdsByArtistIds([1, 2]);
+
+      expect(result).toEqual([10, 20, 30]);
+      expect(mockPrismaService.userArtist.findMany).toHaveBeenCalledWith({
+        where: {
+          artistId: { in: [1, 2] },
+          user: { deletedAt: null },
+        },
+        select: { userId: true },
+      });
+    });
+
+    it('동일 userId 중복 제거', async () => {
+      mockPrismaService.userArtist.findMany.mockResolvedValue([
+        { userId: 10 },
+        { userId: 20 },
+        { userId: 10 },
+        { userId: 30 },
+        { userId: 20 },
+      ]);
+
+      const result = await service.findUserIdsByArtistIds([1, 2, 3]);
+
+      expect(result).toEqual([10, 20, 30]);
+    });
+
+    it('매칭 없으면 빈 배열', async () => {
+      mockPrismaService.userArtist.findMany.mockResolvedValue([]);
+
+      const result = await service.findUserIdsByArtistIds([999]);
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/meilisearch/meilisearch.controller.spec.ts
+++ b/src/meilisearch/meilisearch.controller.spec.ts
@@ -1,0 +1,48 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MeilisearchController } from './meilisearch.controller';
+import { MeilisearchService } from './meilisearch.service';
+
+describe('MeilisearchController', () => {
+  let controller: MeilisearchController;
+  let mockMeilisearchService: any;
+
+  beforeEach(async () => {
+    mockMeilisearchService = {
+      bulkUpsertAll: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MeilisearchController],
+      providers: [
+        { provide: MeilisearchService, useValue: mockMeilisearchService },
+      ],
+    }).compile();
+
+    controller = module.get<MeilisearchController>(MeilisearchController);
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('reindex', () => {
+    it('bulkUpsertAll 호출 후 count 와 함께 success 응답', async () => {
+      mockMeilisearchService.bulkUpsertAll.mockResolvedValue(120);
+
+      const result = await controller.reindex();
+
+      expect(result).toEqual({ success: true, count: 120 });
+      expect(mockMeilisearchService.bulkUpsertAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('아티스트 0건일 때도 success: true (count 0)', async () => {
+      mockMeilisearchService.bulkUpsertAll.mockResolvedValue(0);
+
+      const result = await controller.reindex();
+
+      expect(result).toEqual({ success: true, count: 0 });
+    });
+  });
+});

--- a/src/meilisearch/meilisearch.service.spec.ts
+++ b/src/meilisearch/meilisearch.service.spec.ts
@@ -1,0 +1,146 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from 'prisma/prisma.service';
+import { MeilisearchService } from './meilisearch.service';
+
+const mockIndex = {
+  updateSettings: jest.fn(),
+  addDocuments: jest.fn(),
+  search: jest.fn(),
+};
+
+jest.mock('meilisearch', () => ({
+  MeiliSearch: jest.fn().mockImplementation(() => ({
+    index: jest.fn(() => mockIndex),
+  })),
+}));
+
+describe('MeilisearchService', () => {
+  let service: MeilisearchService;
+  let mockPrismaService: any;
+  let mockConfigService: any;
+
+  beforeEach(async () => {
+    mockPrismaService = {
+      representativeArtist: {
+        findMany: jest.fn(),
+      },
+    };
+
+    mockConfigService = {
+      get: jest.fn((key: string) => {
+        if (key === 'MEILISEARCH_HOST') return 'http://localhost:7700';
+        if (key === 'MEILISEARCH_API_KEY') return 'test-key';
+        return undefined;
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        MeilisearchService,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<MeilisearchService>(MeilisearchService);
+
+    // onModuleInit 시뮬레이션 — index 인스턴스 주입
+    await service.onModuleInit();
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('onModuleInit', () => {
+    it('index settings 가 searchableAttributes / filterableAttributes 로 설정됨', async () => {
+      await service.onModuleInit();
+
+      expect(mockIndex.updateSettings).toHaveBeenCalledWith({
+        searchableAttributes: ['artistName'],
+        filterableAttributes: ['genreId'],
+      });
+    });
+  });
+
+  describe('bulkUpsertAll', () => {
+    it('아티스트가 0건이면 addDocuments 호출 안 하고 0 반환', async () => {
+      mockPrismaService.representativeArtist.findMany.mockResolvedValue([]);
+
+      const result = await service.bulkUpsertAll();
+
+      expect(result).toBe(0);
+      expect(mockIndex.addDocuments).not.toHaveBeenCalled();
+    });
+
+    it('아티스트 목록을 인덱스에 push 하고 건수 반환', async () => {
+      const artists = [
+        { id: 1, artistName: 'NewJeans', genreId: 1 },
+        { id: 2, artistName: 'IVE', genreId: 1 },
+        { id: 3, artistName: 'aespa', genreId: 1 },
+      ];
+      mockPrismaService.representativeArtist.findMany.mockResolvedValue(
+        artists,
+      );
+
+      const result = await service.bulkUpsertAll();
+
+      expect(result).toBe(3);
+      expect(mockIndex.addDocuments).toHaveBeenCalledWith(artists, {
+        primaryKey: 'id',
+      });
+      expect(
+        mockPrismaService.representativeArtist.findMany,
+      ).toHaveBeenCalledWith({
+        select: { id: true, artistName: true, genreId: true },
+      });
+    });
+  });
+
+  describe('search', () => {
+    it('Meilisearch 결과를 ids/totalCount 형태로 변환', async () => {
+      mockIndex.search.mockResolvedValue({
+        hits: [
+          { id: 10, artistName: 'NewJeans' },
+          { id: 20, artistName: 'IVE' },
+        ],
+        estimatedTotalHits: 50,
+      });
+
+      const result = await service.search('keyword', 0, 20);
+
+      expect(result).toEqual({ ids: [10, 20], totalCount: 50 });
+      expect(mockIndex.search).toHaveBeenCalledWith('keyword', {
+        offset: 0,
+        limit: 20,
+      });
+    });
+
+    it('estimatedTotalHits 가 없으면 hits.length 사용 (fallback)', async () => {
+      mockIndex.search.mockResolvedValue({
+        hits: [
+          { id: 1, artistName: 'A' },
+          { id: 2, artistName: 'B' },
+        ],
+      });
+
+      const result = await service.search('k', 0, 10);
+
+      expect(result).toEqual({ ids: [1, 2], totalCount: 2 });
+    });
+
+    it('hits 비어있으면 빈 ids + totalCount 0 (fallback)', async () => {
+      mockIndex.search.mockResolvedValue({
+        hits: [],
+        estimatedTotalHits: 0,
+      });
+
+      const result = await service.search('nothing', 0, 10);
+
+      expect(result).toEqual({ ids: [], totalCount: 0 });
+    });
+  });
+});

--- a/src/search/search.service.spec.ts
+++ b/src/search/search.service.spec.ts
@@ -1,13 +1,14 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { PrismaService } from 'prisma/prisma.service';
 import { SearchService } from './search.service';
+import { MeilisearchService } from '../meilisearch/meilisearch.service';
 import { RepresentativeArtistResponseDto } from './dto/representative-artist-response.dto';
 
 describe('SearchService', () => {
   let service: SearchService;
   let mockPrismaService: any;
+  let mockMeilisearchService: any;
 
-  // Mock 데이터
   const mockRepresentativeArtists = [
     {
       id: 1,
@@ -30,8 +31,10 @@ describe('SearchService', () => {
   beforeEach(async () => {
     mockPrismaService = {
       $transaction: jest.fn((queries) => {
-        // Transaction에 전달된 Promise들을 실행하고 결과를 배열로 반환
-        return Promise.all(queries);
+        if (Array.isArray(queries)) {
+          return Promise.all(queries);
+        }
+        return queries(mockPrismaService);
       }),
       representativeArtist: {
         findMany: jest.fn(),
@@ -43,25 +46,28 @@ describe('SearchService', () => {
       concert: {
         findMany: jest.fn(),
         count: jest.fn(),
+        findUnique: jest.fn(),
       },
       searchSection: {
         findMany: jest.fn(),
       },
     };
 
+    mockMeilisearchService = {
+      search: jest.fn(),
+      bulkUpsertAll: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         SearchService,
-        {
-          provide: PrismaService,
-          useValue: mockPrismaService,
-        },
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: MeilisearchService, useValue: mockMeilisearchService },
       ],
     }).compile();
 
     service = module.get<SearchService>(SearchService);
 
-    // Mock 리셋
     jest.clearAllMocks();
   });
 
@@ -71,7 +77,6 @@ describe('SearchService', () => {
 
   describe('getArtistSearchResults', () => {
     it('키워드 없이 아티스트 검색 - 성공', async () => {
-      // Given
       const cursor = undefined;
       const size = 10;
       const keyword = undefined;
@@ -81,14 +86,12 @@ describe('SearchService', () => {
       );
       mockPrismaService.representativeArtist.count.mockResolvedValue(2);
 
-      // When
       const result = await service.getArtistSearchResults(
         cursor,
         size,
         keyword,
       );
 
-      // Then
       const expectedData = mockRepresentativeArtists.map(
         (artist) => new RepresentativeArtistResponseDto(artist),
       );
@@ -99,60 +102,108 @@ describe('SearchService', () => {
       expect(
         mockPrismaService.representativeArtist.findMany,
       ).toHaveBeenCalledWith({
-        where: {},
         orderBy: [{ genreId: 'asc' }, { id: 'asc' }],
         skip: 0,
         cursor: undefined,
         take: size,
       });
-
-      expect(mockPrismaService.representativeArtist.count).toHaveBeenCalledWith(
-        {
-          where: {},
-        },
-      );
+      expect(
+        mockPrismaService.representativeArtist.count,
+      ).toHaveBeenCalledWith();
+      expect(mockMeilisearchService.search).not.toHaveBeenCalled();
     });
 
-    it('키워드로 아티스트 검색 - 성공', async () => {
-      // Given
+    it('키워드로 아티스트 검색 (Meilisearch) - 성공', async () => {
       const cursor = undefined;
       const size = 10;
       const keyword = 'New';
       const filteredArtists = [mockRepresentativeArtists[0]];
 
+      mockMeilisearchService.search.mockResolvedValue({
+        ids: [1],
+        totalCount: 1,
+      });
       mockPrismaService.representativeArtist.findMany.mockResolvedValue(
         filteredArtists,
       );
-      mockPrismaService.representativeArtist.count.mockResolvedValue(1);
 
-      // When
       const result = await service.getArtistSearchResults(
         cursor,
         size,
         keyword,
       );
 
-      // Then
       const expectedData = filteredArtists.map(
         (artist) => new RepresentativeArtistResponseDto(artist),
       );
       expect(result.data).toEqual(expectedData);
-      expect(result.cursor).toBe(1);
+      // ids.length(1) < limit(10) 이므로 다음 페이지 없음
+      expect(result.cursor).toBeNull();
       expect(result.totalCount).toBe(1);
 
+      expect(mockMeilisearchService.search).toHaveBeenCalledWith(
+        keyword,
+        0,
+        10,
+      );
       expect(
         mockPrismaService.representativeArtist.findMany,
       ).toHaveBeenCalledWith({
-        where: { artistName: { contains: keyword } },
-        orderBy: [{ genreId: 'asc' }, { id: 'asc' }],
-        skip: 0,
-        cursor: undefined,
-        take: size,
+        where: { id: { in: [1] } },
       });
     });
 
-    it('커서를 사용한 페이지네이션 - 성공', async () => {
-      // Given
+    it('키워드 검색 + 다음 페이지 cursor 발급 - 성공', async () => {
+      const cursor = undefined;
+      const size = 2;
+      const keyword = 'k';
+
+      mockMeilisearchService.search.mockResolvedValue({
+        ids: [1, 2],
+        totalCount: 5,
+      });
+      mockPrismaService.representativeArtist.findMany.mockResolvedValue(
+        mockRepresentativeArtists,
+      );
+
+      const result = await service.getArtistSearchResults(
+        cursor,
+        size,
+        keyword,
+      );
+
+      // ids.length(2) === limit(2) → cursor = offset(0) + limit(2) = 2
+      expect(result.cursor).toBe(2);
+      expect(result.totalCount).toBe(5);
+      expect(mockMeilisearchService.search).toHaveBeenCalledWith(keyword, 0, 2);
+    });
+
+    it('키워드 검색 결과가 없을 때 - 빈 응답', async () => {
+      const cursor = undefined;
+      const size = 10;
+      const keyword = 'NonExistent';
+
+      mockMeilisearchService.search.mockResolvedValue({
+        ids: [],
+        totalCount: 0,
+      });
+
+      const result = await service.getArtistSearchResults(
+        cursor,
+        size,
+        keyword,
+      );
+
+      expect(result.data).toEqual([]);
+      expect(result.cursor).toBeNull();
+      expect(result.totalCount).toBe(0);
+      // ids 비어있을 때 DB 조회 스킵
+      expect(
+        mockPrismaService.representativeArtist.findMany,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('cursor 페이지네이션 (키워드 없음) - 성공', async () => {
       const cursor = 1;
       const size = 10;
       const keyword = undefined;
@@ -163,14 +214,12 @@ describe('SearchService', () => {
       );
       mockPrismaService.representativeArtist.count.mockResolvedValue(2);
 
-      // When
       const result = await service.getArtistSearchResults(
         cursor,
         size,
         keyword,
       );
 
-      // Then
       const expectedData = nextPageArtists.map(
         (artist) => new RepresentativeArtistResponseDto(artist),
       );
@@ -181,7 +230,6 @@ describe('SearchService', () => {
       expect(
         mockPrismaService.representativeArtist.findMany,
       ).toHaveBeenCalledWith({
-        where: {},
         orderBy: [{ genreId: 'asc' }, { id: 'asc' }],
         skip: 1,
         cursor: { id: cursor },
@@ -189,38 +237,13 @@ describe('SearchService', () => {
       });
     });
 
-    it('검색 결과가 없을 때 - 성공', async () => {
-      // Given
-      const cursor = undefined;
-      const size = 10;
-      const keyword = 'NonExistent';
-
-      mockPrismaService.representativeArtist.findMany.mockResolvedValue([]);
-      mockPrismaService.representativeArtist.count.mockResolvedValue(0);
-
-      // When
-      const result = await service.getArtistSearchResults(
-        cursor,
-        size,
-        keyword,
-      );
-
-      // Then
-      expect(result.data).toEqual([]);
-      expect(result.cursor).toBeNull();
-      expect(result.totalCount).toBe(0);
-    });
-
     it('데이터베이스 에러 발생 - 실패', async () => {
-      // Given
       const cursor = undefined;
       const size = 10;
       const keyword = undefined;
 
-      // Transaction 내부에서 에러가 발생하도록 설정
       mockPrismaService.$transaction.mockRejectedValue(new Error('DB Error'));
 
-      // When & Then
       await expect(
         service.getArtistSearchResults(cursor, size, keyword),
       ).rejects.toThrow('DB Error');

--- a/src/search/search.service.ts
+++ b/src/search/search.service.ts
@@ -173,6 +173,7 @@ export class SearchService {
     // 5. LATEST: phase 순서 (ONGOING → UPCOMING → COMPLETED → CANCELED)
     type PhaseDef = {
       status: ConcertStatus;
+      extraWhere?: Prisma.ConcertWhereInput;
       orderBy: Prisma.ConcertOrderByWithRelationInput[];
       cursorBuilder: (
         c: NonNullable<typeof cursorConcert>,
@@ -189,6 +190,7 @@ export class SearchService {
       },
       {
         status: ConcertStatus.UPCOMING,
+        extraWhere: { startDate: { not: null } },
         orderBy: [{ startDate: 'asc' }, { id: 'asc' }],
         cursorBuilder: (c) => ({
           startDate_id: { startDate: c.startDate, id: c.id },
@@ -208,6 +210,12 @@ export class SearchService {
           startDate_id: { startDate: c.startDate, id: c.id },
         }),
       },
+      {
+        status: ConcertStatus.UPCOMING,
+        extraWhere: { startDate: null },
+        orderBy: [{ id: 'desc' }],
+        cursorBuilder: (c) => ({ id: c.id }),
+      },
     ];
 
     const allowedStatuses = explicitStatuses
@@ -218,7 +226,17 @@ export class SearchService {
       : ALL_PHASES;
 
     const cursorPhaseIdx = cursorConcert
-      ? activePhases.findIndex((p) => p.status === cursorConcert.status)
+      ? activePhases.findIndex((p) => {
+          if (p.status !== cursorConcert.status) return false;
+          // UPCOMING은 두 phase로 분리되어 있어 startDate null 여부로 구분
+          if (p.status === ConcertStatus.UPCOMING) {
+            const isNoDatePhase = p.extraWhere?.startDate === null;
+            return isNoDatePhase
+              ? cursorConcert.startDate === null
+              : cursorConcert.startDate !== null;
+          }
+          return true;
+        })
       : -1;
     const startIdx = cursorPhaseIdx >= 0 ? cursorPhaseIdx : 0;
 
@@ -238,6 +256,7 @@ export class SearchService {
                 {
                   status: phase.status as Prisma.ConcertWhereInput['status'],
                 },
+                phase.extraWhere ?? {},
               ],
             },
             orderBy: phase.orderBy,


### PR DESCRIPTION
## #️⃣ Issue Number
> Closed #278 

## 📝 요약(Summary)
> 콘서트 검색 NULL 정렬 + Artist unique 추가 + 테스트 보강

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [x] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- MySQL ORDER BY col ASC 가 NULL을 가장 먼저 배치 
- LATEST 정렬에 phase 하나 더 추가 -> 일정 미정 콘서트를 phase로 분리하여 처리
- Artist 테이블에 unique 제약 추가
- migration 하다가 충돌 발생 -> 은서가 새로 추가한 crawl_history + schedule에 인덱스
- 따라서 이 부분을 prisma에 그대로 모델 생성하고 migration 파일 적용하고 applied된 상태로 처리 후 artist unique 마이그레이션 진행
- 6차스프린트 누락된 테스트 코드 추가 

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
