### PR TITLE
✨feat:  #311 콘서트 아티스트 Meilisearch 인덱스 + 매칭 서비스

### DIFF
--- a/src/meilisearch/concert-artist-index.service.spec.ts
+++ b/src/meilisearch/concert-artist-index.service.spec.ts
@@ -1,0 +1,161 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ConcertArtistIndexService } from './concert-artist-index.service';
+
+const mockIndex = {
+  updateSettings: jest.fn(),
+  addDocuments: jest.fn(),
+  search: jest.fn(),
+};
+
+jest.mock('meilisearch', () => ({
+  MeiliSearch: jest.fn().mockImplementation(() => ({
+    index: jest.fn(() => mockIndex),
+  })),
+  Meilisearch: jest.fn().mockImplementation(() => ({
+    index: jest.fn(() => mockIndex),
+  })),
+}));
+
+describe('ConcertArtistIndexService', () => {
+  let service: ConcertArtistIndexService;
+  let mockPrismaService: any;
+  let mockConfigService: any;
+
+  beforeEach(async () => {
+    mockPrismaService = {
+      artist: {
+        findMany: jest.fn(),
+      },
+    };
+
+    mockConfigService = {
+      get: jest.fn((key: string) => {
+        if (key === 'MEILISEARCH_HOST') return 'http://localhost:7700';
+        if (key === 'MEILISEARCH_API_KEY') return 'test-key';
+        return undefined;
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ConcertArtistIndexService,
+        { provide: PrismaService, useValue: mockPrismaService },
+        { provide: ConfigService, useValue: mockConfigService },
+      ],
+    }).compile();
+
+    service = module.get<ConcertArtistIndexService>(ConcertArtistIndexService);
+
+    // onModuleInit 시뮬레이션 — index 인스턴스 주입
+    await service.onModuleInit();
+
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('onModuleInit', () => {
+    it('index settings 가 name/searchNames searchable 로 설정됨', async () => {
+      await service.onModuleInit();
+
+      expect(mockIndex.updateSettings).toHaveBeenCalledWith({
+        searchableAttributes: ['name', 'searchNames'],
+      });
+    });
+  });
+
+  describe('bulkUpsertAll', () => {
+    it('아티스트가 0건이면 addDocuments 호출 안 하고 0 반환', async () => {
+      mockPrismaService.artist.findMany.mockResolvedValue([]);
+
+      const result = await service.bulkUpsertAll();
+
+      expect(result).toBe(0);
+      expect(mockIndex.addDocuments).not.toHaveBeenCalled();
+    });
+
+    it('"영문 (한글)" 형태의 artist를 통짜/영문/한글로 분해해 색인', async () => {
+      mockPrismaService.artist.findMany.mockResolvedValue([
+        { id: 1, artist: 'MADKID (매드키드)' },
+      ]);
+
+      const result = await service.bulkUpsertAll();
+
+      expect(result).toBe(1);
+      expect(mockIndex.addDocuments).toHaveBeenCalledWith(
+        [
+          {
+            id: 1,
+            name: 'MADKID (매드키드)',
+            searchNames: expect.arrayContaining([
+              'MADKID (매드키드)',
+              'MADKID',
+              '매드키드',
+            ]),
+          },
+        ],
+        { primaryKey: 'id' },
+      );
+    });
+
+    it('공백 포함 이름은 공백 제거 변형까지 색인', async () => {
+      mockPrismaService.artist.findMany.mockResolvedValue([
+        { id: 2, artist: 'ONE OK ROCK (원 오크 록)' },
+      ]);
+
+      await service.bulkUpsertAll();
+
+      const [docs] = mockIndex.addDocuments.mock.calls[0];
+      expect(docs[0].searchNames).toEqual(
+        expect.arrayContaining([
+          'ONE OK ROCK', // 분해된 영문
+          '원 오크 록', // 분해된 한글
+          'ONEOKROCK', // 공백 제거 변형
+          '원오크록', // 공백 제거 변형
+        ]),
+      );
+    });
+
+    it('괄호 없는 artist는 원본 그대로 색인', async () => {
+      mockPrismaService.artist.findMany.mockResolvedValue([
+        { id: 3, artist: 'toe' },
+      ]);
+
+      await service.bulkUpsertAll();
+
+      const [docs] = mockIndex.addDocuments.mock.calls[0];
+      expect(docs[0].searchNames).toEqual(['toe']);
+    });
+  });
+
+  describe('matchArtist', () => {
+    it('검색 hits를 artistId/name으로 매핑해 반환', async () => {
+      mockIndex.search.mockResolvedValue({
+        hits: [
+          { id: 1, name: 'ONE OK ROCK (원 오크 록)', searchNames: [] },
+          { id: 7, name: 'MADKID (매드키드)', searchNames: [] },
+        ],
+      });
+
+      const result = await service.matchArtist('원오크록');
+
+      expect(mockIndex.search).toHaveBeenCalledWith('원오크록', { limit: 3 });
+      expect(result).toEqual([
+        { artistId: 1, name: 'ONE OK ROCK (원 오크 록)' },
+        { artistId: 7, name: 'MADKID (매드키드)' },
+      ]);
+    });
+
+    it('hits가 없으면 빈 배열 반환 (NO_MATCH)', async () => {
+      mockIndex.search.mockResolvedValue({ hits: [] });
+
+      const result = await service.matchArtist('없는 아티스트');
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/meilisearch/concert-artist-index.service.ts
+++ b/src/meilisearch/concert-artist-index.service.ts
@@ -29,10 +29,17 @@ export class ConcertArtistIndexService implements OnModuleInit {
 
   async onModuleInit() {
     this.index = this.client.index<ConcertArtistDocument>(INDEX_NAME);
-    await this.index.updateSettings({
-      searchableAttributes: ['name', 'searchNames'],
-    });
-    this.logger.log('concert-artists index settings ready');
+    try {
+      await this.index.updateSettings({
+        searchableAttributes: ['name', 'searchNames'],
+      });
+      this.logger.log('concert-artists index settings ready');
+    } catch (error) {
+      this.logger.error(
+        'Failed to initialize Meilisearch index settings',
+        error,
+      );
+    }
   }
 
   async bulkUpsertAll(): Promise<number> {
@@ -64,6 +71,9 @@ export class ConcertArtistIndexService implements OnModuleInit {
   async matchArtist(
     extractName: string,
   ): Promise<{ artistId: number; name: string }[]> {
+    if (!extractName || !extractName.trim()) {
+      return [];
+    }
     const result = await this.index.search(extractName, { limit: 3 });
     return result.hits.map((hit) => ({ artistId: hit.id, name: hit.name }));
   }

--- a/src/meilisearch/concert-artist-index.service.ts
+++ b/src/meilisearch/concert-artist-index.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Index, Meilisearch } from 'meilisearch';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../../prisma/prisma.service';
+
+export interface ConcertArtistDocument {
+  id: number;
+  name: string;
+  searchNames: string[];
+}
+
+const INDEX_NAME = 'concert-artists';
+
+@Injectable()
+export class ConcertArtistIndexService implements OnModuleInit {
+  private readonly logger = new Logger(ConcertArtistIndexService.name);
+  private readonly client: Meilisearch;
+  private index: Index<ConcertArtistDocument>;
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly prisma: PrismaService,
+  ) {
+    this.client = new Meilisearch({
+      host: this.configService.get<string>('MEILISEARCH_HOST'),
+      apiKey: this.configService.get<string>('MEILISEARCH_API_KEY'),
+    });
+  }
+
+  async onModuleInit() {
+    this.index = this.client.index<ConcertArtistDocument>(INDEX_NAME);
+    await this.index.updateSettings({
+      searchableAttributes: ['name', 'searchNames'],
+    });
+    this.logger.log('concert-artists index settings ready');
+  }
+
+  async bulkUpsertAll(): Promise<number> {
+    const artists = await this.prisma.artist.findMany({
+      select: { id: true, artist: true },
+    });
+    if (artists.length === 0) {
+      this.logger.log('concert-artists reindex skipped: no artists');
+      return 0;
+    }
+    await this.index.addDocuments(
+      artists.map((a) => {
+        const names = this.splitArtistName(a.artist);
+        return {
+          id: a.id,
+          name: a.artist,
+          // 공백 제거 변형 자동 추가 ("원 오크 록" ↔ "원오크록" 흡수)
+          searchNames: [
+            ...new Set([...names, ...names.map((n) => n.replace(/\s+/g, ''))]),
+          ],
+        };
+      }),
+      { primaryKey: 'id' },
+    );
+    this.logger.log(`concert-artists reindex enqueued: ${artists.length}건`);
+    return artists.length;
+  }
+
+  async matchArtist(
+    extractName: string,
+  ): Promise<{ artistId: number; name: string }[]> {
+    const result = await this.index.search(extractName, { limit: 3 });
+    return result.hits.map((hit) => ({ artistId: hit.id, name: hit.name }));
+  }
+
+  /**
+   * 분해하여 meilisearch에 색인
+   */
+  private splitArtistName(raw: string): string[] {
+    const variants = new Set<string>([raw]);
+    const match = raw.match(/^(.*?)\s*[（(]([^()（）]+)[)）]\s*$/);
+    if (match) {
+      const base = match[1].trim();
+      const inParens = match[2].trim();
+      if (base) variants.add(base);
+      if (inParens) variants.add(inParens);
+    }
+    return [...variants];
+  }
+}

--- a/src/meilisearch/meilisearch.controller.spec.ts
+++ b/src/meilisearch/meilisearch.controller.spec.ts
@@ -1,13 +1,18 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { MeilisearchController } from './meilisearch.controller';
 import { MeilisearchService } from './meilisearch.service';
+import { ConcertArtistIndexService } from './concert-artist-index.service';
 
 describe('MeilisearchController', () => {
   let controller: MeilisearchController;
   let mockMeilisearchService: any;
+  let mockConcertArtistIndexService: any;
 
   beforeEach(async () => {
     mockMeilisearchService = {
+      bulkUpsertAll: jest.fn(),
+    };
+    mockConcertArtistIndexService = {
       bulkUpsertAll: jest.fn(),
     };
 
@@ -15,6 +20,10 @@ describe('MeilisearchController', () => {
       controllers: [MeilisearchController],
       providers: [
         { provide: MeilisearchService, useValue: mockMeilisearchService },
+        {
+          provide: ConcertArtistIndexService,
+          useValue: mockConcertArtistIndexService,
+        },
       ],
     }).compile();
 
@@ -41,6 +50,28 @@ describe('MeilisearchController', () => {
       mockMeilisearchService.bulkUpsertAll.mockResolvedValue(0);
 
       const result = await controller.reindex();
+
+      expect(result).toEqual({ success: true, count: 0 });
+    });
+  });
+
+  describe('reindexConcertArtists', () => {
+    it('콘서트 아티스트 인덱스 bulkUpsertAll 호출 후 success 응답', async () => {
+      mockConcertArtistIndexService.bulkUpsertAll.mockResolvedValue(45);
+
+      const result = await controller.reindexConcertArtists();
+
+      expect(result).toEqual({ success: true, count: 45 });
+      expect(
+        mockConcertArtistIndexService.bulkUpsertAll,
+      ).toHaveBeenCalledTimes(1);
+      expect(mockMeilisearchService.bulkUpsertAll).not.toHaveBeenCalled();
+    });
+
+    it('아티스트 0건일 때도 success: true (count 0)', async () => {
+      mockConcertArtistIndexService.bulkUpsertAll.mockResolvedValue(0);
+
+      const result = await controller.reindexConcertArtists();
 
       expect(result).toEqual({ success: true, count: 0 });
     });

--- a/src/meilisearch/meilisearch.controller.ts
+++ b/src/meilisearch/meilisearch.controller.ts
@@ -2,13 +2,17 @@ import { Controller, Logger, Post } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import { API_PREFIX } from '../common/constants/api-prefix';
 import { MeilisearchService } from './meilisearch.service';
+import { ConcertArtistIndexService } from './concert-artist-index.service';
 
 @ApiTags('Meilisearch')
 @Controller(`${API_PREFIX}/meilisearch`)
 export class MeilisearchController {
   private readonly logger = new Logger(MeilisearchController.name);
 
-  constructor(private readonly meilisearchService: MeilisearchService) {}
+  constructor(
+    private readonly meilisearchService: MeilisearchService,
+    private readonly concertArtistIndexService: ConcertArtistIndexService,
+  ) {}
 
   @ApiOperation({
     summary: '아티스트 인덱스 수동 재색인',
@@ -19,6 +23,18 @@ export class MeilisearchController {
   async reindex() {
     this.logger.log('Manual Meilisearch reindex triggered');
     const count = await this.meilisearchService.bulkUpsertAll();
+    return { success: true, count };
+  }
+
+  @ApiOperation({
+    summary: '콘서트 아티스트 인덱스 수동 재색인',
+    description:
+      'artists 테이블(searchNames+공백변형 포함)을 concert-artists 인덱스에 push',
+  })
+  @Post('/reindex-concert-artists')
+  async reindexConcertArtists() {
+    this.logger.log('Manual concert-artists reindex triggered');
+    const count = await this.concertArtistIndexService.bulkUpsertAll();
     return { success: true, count };
   }
 }

--- a/src/meilisearch/meilisearch.module.ts
+++ b/src/meilisearch/meilisearch.module.ts
@@ -2,12 +2,18 @@ import { Global, Module } from '@nestjs/common';
 import { MeilisearchService } from './meilisearch.service';
 import { MeilisearchController } from './meilisearch.controller';
 import { PrismaModule } from '../../prisma/prisma.module';
+import { ConcertArtistIndexService } from './concert-artist-index.service';
+import { MeilisearchScheduler } from './meilisearch.scheduler';
 
 @Global()
 @Module({
   imports: [PrismaModule],
   controllers: [MeilisearchController],
-  providers: [MeilisearchService],
-  exports: [MeilisearchService],
+  providers: [
+    MeilisearchService,
+    ConcertArtistIndexService,
+    MeilisearchScheduler,
+  ],
+  exports: [MeilisearchService, ConcertArtistIndexService],
 })
 export class MeilisearchModule {}

--- a/src/meilisearch/meilisearch.scheduler.ts
+++ b/src/meilisearch/meilisearch.scheduler.ts
@@ -1,0 +1,17 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConcertArtistIndexService } from './concert-artist-index.service';
+import { Cron } from '@nestjs/schedule';
+
+@Injectable()
+export class MeilisearchScheduler {
+  private readonly logger = new Logger(MeilisearchScheduler.name);
+
+  constructor(private readonly concertArtistIndex: ConcertArtistIndexService) {}
+
+  // 매주 월요일 13:00 KST — INSERT한 아티스트를 색인에 흡수
+  @Cron('0 13 * * 1', { timeZone: 'Asia/Seoul' })
+  async resyncConcertArtists() {
+    const count = await this.concertArtistIndex.bulkUpsertAll();
+    this.logger.log(`weekly concert-artists resync: ${count}건`);
+  }
+}

--- a/src/meilisearch/meilisearch.scheduler.ts
+++ b/src/meilisearch/meilisearch.scheduler.ts
@@ -11,7 +11,11 @@ export class MeilisearchScheduler {
   // 매주 월요일 13:00 KST — INSERT한 아티스트를 색인에 흡수
   @Cron('0 13 * * 1', { timeZone: 'Asia/Seoul' })
   async resyncConcertArtists() {
-    const count = await this.concertArtistIndex.bulkUpsertAll();
-    this.logger.log(`weekly concert-artists resync: ${count}건`);
+    try {
+      const count = await this.concertArtistIndex.bulkUpsertAll();
+      this.logger.log(`weekly concert-artists resync: ${count}건`);
+    } catch (error) {
+      this.logger.error('Failed to resync concert artists weekly', error);
+    }
   }
 }


### PR DESCRIPTION
## #️⃣ Issue Number
> Closed #311 

## 📝 요약(Summary)
> MEILISEARCH 기반 아티스트명 매칭 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 기존 representative_artist 검색할때 쓰였던 artist 인덱스랑 다른 concert-artists 인덱스로 매김
- 잡에서 나온 아티스트명바탕으로 공백, 오타, 대소문자 모두 잡아줘서 매칭후 artistid기반으로 콘서트 탐색
- 대표아티스트 검색 느낌으로 생각하면 될 것 같아유
- artist 인덱스는 주마다 1회씩 동기화 에정 + 첫 1회는 api로 색인 

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
