### PR TITLE
✨feat: 추출 job 종결/정리 스케줄러 구현 및 워커 API 정비 

### DIFF
--- a/prisma/migrations/20260717155854_add_alarm_check_to_user_interest_concert/migration.sql
+++ b/prisma/migrations/20260717155854_add_alarm_check_to_user_interest_concert/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `user_interest_concerts` ADD COLUMN `alarm_check` BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -378,6 +378,7 @@ model UserInterestConcert {
   concertTitle String?  @map("concert_title") @db.VarChar(300)
   userNickname String   @map("user_nickname") @db.VarChar(50)
   toastShown   Boolean  @default(false) @map("toast_shown")
+  alarmCheck   Boolean  @default(true) @map("alarm_check")
   createdAt    DateTime @default(now()) @map("created_at")
   updatedAt    DateTime @default(now()) @updatedAt @map("updated_at")
 

--- a/src/extraction/dto/report-fail.dto.ts
+++ b/src/extraction/dto/report-fail.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class ReportFailDto {
+  /** 로그로만 쓴다. 재시도 여부를 가르지 않는다. */
+  @ApiProperty({ description: '추출 실패 사유', required: false })
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/src/extraction/dto/submit-result.dto.ts
+++ b/src/extraction/dto/submit-result.dto.ts
@@ -1,29 +1,9 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsObject, IsOptional, IsString } from 'class-validator';
+import { IsOptional, IsString } from 'class-validator';
 
 export class SubmitResultDto {
-  @ApiProperty({ description: '추출된 공연 정보 필드', required: false })
-  @IsOptional()
-  @IsObject()
-  event?: {
-    title?: string;
-    artist?: string;
-    dates?: string;
-    preTicketingAt?: string;
-    generalTicketingAt?: string;
-  };
-
-  @ApiProperty({ required: false })
+  @ApiProperty({ description: '추출된 아티스트명', required: false })
   @IsOptional()
   @IsString()
-  caption?: string;
-
-  @ApiProperty({ required: false })
-  @IsOptional()
-  @IsString()
-  ocrText?: string;
-
-  @ApiProperty({ required: false, type: [String] })
-  @IsOptional()
-  slides?: string[];
+  artist?: string;
 }

--- a/src/extraction/extraction-internal.controller.ts
+++ b/src/extraction/extraction-internal.controller.ts
@@ -13,6 +13,7 @@ import { Response } from 'express';
 import { WorkerTokenGuard } from './guard/worker-token.guard';
 import { ExtractionService } from './extraction.service';
 import { SubmitResultDto } from './dto/submit-result.dto';
+import { ReportFailDto } from './dto/report-fail.dto';
 
 @ApiExcludeController() // 내부 API - Swagger 노출 제외
 @Controller('internal/extraction-jobs')
@@ -23,8 +24,11 @@ export class ExtractionInternalController {
   @Get('claim')
   async claim(@Res({ passthrough: true }) res: Response) {
     const job = await this.extractionService.claimNext();
-    if (!job) return res.status(204).send();
-    return res.status(200).json({ data: job });
+    if (!job) {
+      res.status(204); // 빈 큐
+      return null;
+    }
+    return job; // -> data: { jobId, instagramUrl }
   }
 
   @Post(':id/result')
@@ -36,8 +40,8 @@ export class ExtractionInternalController {
 
   @Post(':id/fail')
   @HttpCode(200)
-  async reportFail(@Param('id') id: string, @Body() body: { reason?: string }) {
-    const job = await this.extractionService.reportFail(id, body?.reason);
+  async reportFail(@Param('id') id: string, @Body() dto: ReportFailDto) {
+    const job = await this.extractionService.reportFail(id, dto.reason);
     return { jobId: job.id, status: job.status };
   }
 }

--- a/src/extraction/extraction-internal.controller.ts
+++ b/src/extraction/extraction-internal.controller.ts
@@ -25,8 +25,8 @@ export class ExtractionInternalController {
   async claim(@Res({ passthrough: true }) res: Response) {
     const job = await this.extractionService.claimNext();
     if (!job) {
-      res.status(204); // 빈 큐
-      return null;
+      res.status(204).send(); // 빈 큐
+      return;
     }
     return job; // -> data: { jobId, instagramUrl }
   }

--- a/src/extraction/extraction.module.ts
+++ b/src/extraction/extraction.module.ts
@@ -4,10 +4,11 @@ import { ExtractionController } from './extraction.controller';
 import { ExtractionInternalController } from './extraction-internal.controller';
 import { ExtractionService } from './extraction.service';
 import { ExtractionEventsService } from './extraction-events.service';
+import { ExtractionScheduler } from './extraction.scheduler';
 
 @Module({
   imports: [PrismaModule],
   controllers: [ExtractionController, ExtractionInternalController],
-  providers: [ExtractionService, ExtractionEventsService],
+  providers: [ExtractionService, ExtractionEventsService, ExtractionScheduler],
 })
 export class ExtractionModule {}

--- a/src/extraction/extraction.scheduler.spec.ts
+++ b/src/extraction/extraction.scheduler.spec.ts
@@ -1,0 +1,62 @@
+import { Global, Module } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ScheduleModule, SchedulerRegistry } from '@nestjs/schedule';
+import { EventEmitterModule } from '@nestjs/event-emitter';
+import { ConfigModule } from '@nestjs/config';
+import { ExtractionModule } from './extraction.module';
+import { ExtractionService } from './extraction.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { ConcertArtistIndexService } from '../meilisearch/concert-artist-index.service';
+
+// 실제 MeilisearchModule(@Global)이 공급하는 의존성을 부팅 없이 대체
+@Global()
+@Module({
+  providers: [{ provide: ConcertArtistIndexService, useValue: {} }],
+  exports: [ConcertArtistIndexService],
+})
+class FakeMeilisearchModule {}
+
+describe('ExtractionScheduler (module wiring)', () => {
+  let moduleRef: TestingModule;
+  let registry: SchedulerRegistry;
+
+  beforeEach(async () => {
+    moduleRef = await Test.createTestingModule({
+      imports: [
+        ScheduleModule.forRoot(),
+        EventEmitterModule.forRoot(),
+        ConfigModule.forRoot({ isGlobal: true }),
+        FakeMeilisearchModule,
+        ExtractionModule,
+      ],
+    })
+      .overrideProvider(PrismaService)
+      .useValue({ $executeRaw: jest.fn().mockResolvedValue(0) })
+      .compile();
+
+    await moduleRef.init();
+    registry = moduleRef.get(SchedulerRegistry);
+  });
+
+  afterEach(async () => {
+    await moduleRef.close();
+  });
+
+  // ExtractionScheduler가 providers에 빠지면 @Cron이 조용히 등록되지 않는다.
+  it('@Cron 잡 2개가 SchedulerRegistry에 등록된다', () => {
+    expect(registry.getCronJobs().size).toBe(2);
+  });
+
+  it('등록된 cron 콜백이 ExtractionService를 호출한다', async () => {
+    const service = moduleRef.get(ExtractionService);
+    const expire = jest.spyOn(service, 'expireOverdueJobs').mockResolvedValue();
+    const cleanup = jest.spyOn(service, 'cleanupOldJobs').mockResolvedValue(0);
+
+    for (const job of registry.getCronJobs().values()) {
+      await job.fireOnTick();
+    }
+
+    expect(expire).toHaveBeenCalledTimes(1);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/extraction/extraction.scheduler.ts
+++ b/src/extraction/extraction.scheduler.ts
@@ -8,13 +8,13 @@ export class ExtractionScheduler {
 
   constructor(private readonly extractionService: ExtractionService) {}
 
-  // 매분: 워커 사망으로 멈춘 EXTRACTING 잡 종결
-  @Cron(CronExpression.EVERY_MINUTE)
-  async failStaleJobs() {
-    await this.extractionService.failStaleExtracting();
+  // 예산 소진 잡 종결. 클라 응답은 waitForDone 타임아웃이 책임지므로 주기는 느슨해도 된다
+  @Cron(CronExpression.EVERY_30_SECONDS)
+  async expireOverdueJobs() {
+    await this.extractionService.expireOverdueJobs();
   }
 
-  // 매일 04:00 KST: 오래된 잡 종결 삭제
+  // 매일 04:00 KST: 종결 후 7일 지난 잡 삭제
   @Cron('0 4 * * *', { timeZone: 'Asia/Seoul' })
   async cleanupOldJobs() {
     await this.extractionService.cleanupOldJobs();

--- a/src/extraction/extraction.scheduler.ts
+++ b/src/extraction/extraction.scheduler.ts
@@ -1,0 +1,22 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ExtractionService } from './extraction.service';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+@Injectable()
+export class ExtractionScheduler {
+  private readonly logger = new Logger(ExtractionScheduler.name);
+
+  constructor(private readonly extractionService: ExtractionService) {}
+
+  // 매분: 워커 사망으로 멈춘 EXTRACTING 잡 종결
+  @Cron(CronExpression.EVERY_MINUTE)
+  async failStaleJobs() {
+    await this.extractionService.failStaleExtracting();
+  }
+
+  // 매일 04:00 KST: 오래된 잡 종결 삭제
+  @Cron('0 4 * * *', { timeZone: 'Asia/Seoul' })
+  async cleanupOldJobs() {
+    await this.extractionService.cleanupOldJobs();
+  }
+}

--- a/src/extraction/extraction.service.spec.ts
+++ b/src/extraction/extraction.service.spec.ts
@@ -118,7 +118,7 @@ describe('ExtractionService', () => {
         status: 'NO_MATCH',
       });
 
-      await service.submitResult('job1', { event: { artist: '없는아티스트' } });
+      await service.submitResult('job1', { artist: '없는아티스트' });
 
       expect(mockPrisma.extractionJob.update).toHaveBeenCalledWith({
         where: { id: 'job1' },
@@ -144,7 +144,7 @@ describe('ExtractionService', () => {
         status: 'MATCHED',
       });
 
-      await service.submitResult('job1', { event: { artist: '히토리에' } });
+      await service.submitResult('job1', { artist: '히토리에' });
 
       expect(mockConcertIndex.matchArtist).toHaveBeenCalledWith('히토리에');
       expect(mockPrisma.extractionJob.update).toHaveBeenCalledWith({
@@ -167,7 +167,7 @@ describe('ExtractionService', () => {
         status: 'NO_MATCH',
       });
 
-      await service.submitResult('job1', { caption: '아티스트 필드 없음' });
+      await service.submitResult('job1', {});
 
       expect(mockConcertIndex.matchArtist).not.toHaveBeenCalled();
       expect(mockPrisma.extractionJob.update).toHaveBeenCalledWith({
@@ -228,7 +228,7 @@ describe('ExtractionService', () => {
 
       expect(mockEvents.waitForDone).toHaveBeenCalledWith(
         'job1',
-        50_000,
+        30_000,
         expect.any(Function),
       );
       expect(result).toEqual({ result: 'MATCHED', concerts: [] });

--- a/src/extraction/extraction.service.ts
+++ b/src/extraction/extraction.service.ts
@@ -151,6 +151,41 @@ export class ExtractionService {
     return this.toClientResponse(current);
   }
 
+  /**
+   * 좀비 EXTRACTING 잡 종결.
+   * 워커가 claim 후 죽어 응답이 안 온 잡을 NO_MATCH로 확정
+   * 재추출은 안함
+   */
+  async failStaleExtracting(): Promise<number> {
+    const affected = await this.prisma.$executeRaw(Prisma.sql`
+      UPDATE extraction_jobs 
+        SET status = 'NO_MATCH', updated_at = NOW(3)
+      WHERE status = 'EXTRACTING'
+        AND updated_at < NOW(3) - INTERVAL 2 MINUTE
+    `);
+    if (affected > 0) {
+      this.logger.warn(`stale EXTRACTING jobs failed: ${affected}건`);
+    }
+    return affected;
+  }
+
+  /**
+   * 오래된 종결 잡 정리
+   * 종결(MATCHED/NO_MATCH) 후 7일 지난 잡 삭제
+   * -> 큐 테이블 비대 방지 + 오래된 실패 캐시 만료
+   */
+  async cleanupOldJobs(): Promise<number> {
+    const affected = await this.prisma.$executeRaw(Prisma.sql`
+      DELETE FROM extraction_jobs 
+        WHERE status IN ('MATCHED', 'NO_MATCH')
+        AND updated_at < NOW(3) - INTERVAL 7 DAY
+    `);
+    if (affected > 0) {
+      this.logger.log(`old extraction jobs cleaned up: ${affected}건`);
+    }
+    return affected;
+  }
+
   /** DB status -> 클라 result 3종 + concerts 매핑 */
   private async toClientResponse(job: ExtractionJob): Promise<{
     result: ClientResult;

--- a/src/extraction/extraction.service.ts
+++ b/src/extraction/extraction.service.ts
@@ -155,17 +155,17 @@ export class ExtractionService {
    * 예산(WAIT_MS) 소진한 미종결 잡을 NO_MATCH로 종결.
    */
   async expireOverdueJobs(): Promise<void> {
-    const now = new Date();
-    const budgetCutoff = new Date(now.getTime() - this.WAIT_MS);
+    const budgetCutoff = new Date(Date.now() - this.WAIT_MS);
 
-    const expired = await this.prisma.$executeRaw(Prisma.sql`
-      UPDATE extraction_jobs
-        SET status = 'NO_MATCH', updated_at = ${now}
-      WHERE status IN ('PENDING', 'EXTRACTING')
-        AND created_at < ${budgetCutoff}
-    `);
-    if (expired > 0) {
-      this.logger.warn(`extraction jobs expired to NO_MATCH: ${expired}건`);
+    const { count } = await this.prisma.extractionJob.updateMany({
+      where: {
+        status: { in: ['PENDING', 'EXTRACTING'] },
+        createdAt: { lt: budgetCutoff },
+      },
+      data: { status: 'NO_MATCH' },
+    });
+    if (count > 0) {
+      this.logger.warn(`extraction jobs expired to NO_MATCH: ${count}건`);
     }
   }
 
@@ -174,15 +174,16 @@ export class ExtractionService {
    */
   async cleanupOldJobs(): Promise<number> {
     const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    const affected = await this.prisma.$executeRaw(Prisma.sql`
-      DELETE FROM extraction_jobs
-        WHERE status IN ('MATCHED', 'NO_MATCH')
-        AND updated_at < ${cutoff}
-    `);
-    if (affected > 0) {
-      this.logger.log(`old extraction jobs cleaned up: ${affected}건`);
+    const { count } = await this.prisma.extractionJob.deleteMany({
+      where: {
+        status: { in: ['MATCHED', 'NO_MATCH'] },
+        updatedAt: { lt: cutoff },
+      },
+    });
+    if (count > 0) {
+      this.logger.log(`old extraction jobs cleaned up: ${count}건`);
     }
-    return affected;
+    return count;
   }
 
   /** DB status -> 클라 result 2종 + concerts 매핑 */

--- a/src/extraction/extraction.service.ts
+++ b/src/extraction/extraction.service.ts
@@ -20,7 +20,7 @@ type ClientResult = 'MATCHED' | 'NO_MATCH';
 @Injectable()
 export class ExtractionService {
   private readonly logger = new Logger(ExtractionService.name);
-  private readonly WAIT_MS = 50_000;
+  private readonly WAIT_MS = 30_000;
 
   constructor(
     private readonly prisma: PrismaService,
@@ -93,7 +93,7 @@ export class ExtractionService {
     const job = await this.findById(jobId);
     if (job.status !== 'EXTRACTING') return job;
 
-    const candidateIds = await this.matchConcertIds(dto.event?.artist);
+    const candidateIds = await this.matchConcertIds(dto.artist);
     const status: ExtractionStatus =
       candidateIds.length > 0 ? 'MATCHED' : 'NO_MATCH';
 
@@ -152,33 +152,32 @@ export class ExtractionService {
   }
 
   /**
-   * 좀비 EXTRACTING 잡 종결.
-   * 워커가 claim 후 죽어 응답이 안 온 잡을 NO_MATCH로 확정
-   * 재추출은 안함
+   * 예산(WAIT_MS) 소진한 미종결 잡을 NO_MATCH로 종결.
    */
-  async failStaleExtracting(): Promise<number> {
-    const affected = await this.prisma.$executeRaw(Prisma.sql`
-      UPDATE extraction_jobs 
-        SET status = 'NO_MATCH', updated_at = NOW(3)
-      WHERE status = 'EXTRACTING'
-        AND updated_at < NOW(3) - INTERVAL 2 MINUTE
+  async expireOverdueJobs(): Promise<void> {
+    const now = new Date();
+    const budgetCutoff = new Date(now.getTime() - this.WAIT_MS);
+
+    const expired = await this.prisma.$executeRaw(Prisma.sql`
+      UPDATE extraction_jobs
+        SET status = 'NO_MATCH', updated_at = ${now}
+      WHERE status IN ('PENDING', 'EXTRACTING')
+        AND created_at < ${budgetCutoff}
     `);
-    if (affected > 0) {
-      this.logger.warn(`stale EXTRACTING jobs failed: ${affected}건`);
+    if (expired > 0) {
+      this.logger.warn(`extraction jobs expired to NO_MATCH: ${expired}건`);
     }
-    return affected;
   }
 
   /**
-   * 오래된 종결 잡 정리
-   * 종결(MATCHED/NO_MATCH) 후 7일 지난 잡 삭제
-   * -> 큐 테이블 비대 방지 + 오래된 실패 캐시 만료
+   * 종결(MATCHED/NO_MATCH) 후 7일 지난 잡 삭제.
    */
   async cleanupOldJobs(): Promise<number> {
+    const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
     const affected = await this.prisma.$executeRaw(Prisma.sql`
-      DELETE FROM extraction_jobs 
+      DELETE FROM extraction_jobs
         WHERE status IN ('MATCHED', 'NO_MATCH')
-        AND updated_at < NOW(3) - INTERVAL 7 DAY
+        AND updated_at < ${cutoff}
     `);
     if (affected > 0) {
       this.logger.log(`old extraction jobs cleaned up: ${affected}건`);
@@ -186,7 +185,7 @@ export class ExtractionService {
     return affected;
   }
 
-  /** DB status -> 클라 result 3종 + concerts 매핑 */
+  /** DB status -> 클라 result 2종 + concerts 매핑 */
   private async toClientResponse(job: ExtractionJob): Promise<{
     result: ClientResult;
     concerts: ConcertResponseDto[];
@@ -203,7 +202,7 @@ export class ExtractionService {
     const concerts = await this.prisma.concert.findMany({
       where: { id: { in: candidateIds } },
     });
-    // candidateis 순서(정확도/공연일 순) 보존
+    // candidates 순서(정확도/공연일 순) 보존
     const byId = new Map(concerts.map((c) => [c.id, c]));
     const ordered = candidateIds
       .map((id) => byId.get(id))

--- a/src/meilisearch/meilisearch.controller.spec.ts
+++ b/src/meilisearch/meilisearch.controller.spec.ts
@@ -62,9 +62,9 @@ describe('MeilisearchController', () => {
       const result = await controller.reindexConcertArtists();
 
       expect(result).toEqual({ success: true, count: 45 });
-      expect(
-        mockConcertArtistIndexService.bulkUpsertAll,
-      ).toHaveBeenCalledTimes(1);
+      expect(mockConcertArtistIndexService.bulkUpsertAll).toHaveBeenCalledTimes(
+        1,
+      );
       expect(mockMeilisearchService.bulkUpsertAll).not.toHaveBeenCalled();
     });
 

--- a/src/meilisearch/meilisearch.service.ts
+++ b/src/meilisearch/meilisearch.service.ts
@@ -29,11 +29,18 @@ export class MeilisearchService implements OnModuleInit {
 
   async onModuleInit() {
     this.index = this.client.index<ArtistDocument>(INDEX_NAME);
-    await this.index.updateSettings({
-      searchableAttributes: ['artistName'],
-      filterableAttributes: ['genreId'],
-    });
-    this.logger.log('Meilisearch index settings ready');
+    try {
+      await this.index.updateSettings({
+        searchableAttributes: ['artistName'],
+        filterableAttributes: ['genreId'],
+      });
+      this.logger.log('Meilisearch index settings ready');
+    } catch (error) {
+      this.logger.error(
+        'Failed to initialize Meilisearch index settings',
+        error,
+      );
+    }
   }
 
   async bulkUpsertAll(): Promise<number> {


### PR DESCRIPTION
## #️⃣ Issue Number
> Closed #318 

## 📝 요약(Summary)
> 인스타 추출 잡의 정리 담당하는 스케줄러 구현 및 워커 내부 API 스펙에 맞게 정리 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 대기 시간을 초과한 미종결 잡에 대해서는 NO_MATCH로 종결
- 7일이 지난 끝난 잡들에 대해서 삭제
- 워커에서 받는 응답을 artist 하나로 줄임 
- ocr 사용안하고 캡션으로 artist로만 떼오면 10초안으로 가능 (계속 테스트 중) 
- 추후 알림 바텀시트를 위해 alarm_check 필드 추가 

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
