### PR TITLE
✨feat: 앱 진입 알림 조회 및 노출 처리 API 추가 

### DIFF
--- a/src/common/constants/api-prefix.ts
+++ b/src/common/constants/api-prefix.ts
@@ -1,1 +1,1 @@
-export const API_PREFIX = 'api/v6';
+export const API_PREFIX = 'api/v7';

--- a/src/notification/dto/response/entry-alert-response.dto.ts
+++ b/src/notification/dto/response/entry-alert-response.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum EntryAlertKind {
+  AUTO_REMOVED_COMPLETED = 'AUTO_REMOVED_COMPLETED',
+  AUTO_REMOVED_CANCELED = 'AUTO_REMOVED_CANCELED',
+  REQUEST_REGISTERED = 'REQUEST_REGISTERED',
+  REQUEST_FAILED = 'REQUEST_FAILED',
+}
+
+export class EntryAlertItemDto {
+  @ApiProperty({ enum: EntryAlertKind })
+  kind: EntryAlertKind;
+
+  @ApiProperty({ example: '자동 정리된 공연 2' })
+  title: string;
+
+  @ApiProperty({ example: '오크 록 내한 공연 외 1건이 자동 정리 됐어요' })
+  content: string;
+
+  @ApiProperty({
+    required: false,
+    example: 55,
+    description: 'REQUEST_REGISTERED 때 콘서트 상세 이동용 ID',
+  })
+  concertId?: number;
+}
+
+export class EntryAlertResponseDto {
+  @ApiProperty({ type: [EntryAlertItemDto] })
+  items: EntryAlertItemDto[];
+
+  constructor(items: EntryAlertItemDto[]) {
+    this.items = items;
+  }
+}
+

--- a/src/notification/dto/response/entry-alert-response.dto.ts
+++ b/src/notification/dto/response/entry-alert-response.dto.ts
@@ -33,4 +33,3 @@ export class EntryAlertResponseDto {
     this.items = items;
   }
 }
-

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -3,12 +3,12 @@ import {
   Controller,
   Delete,
   Get,
+  HttpCode,
   Param,
   ParseIntPipe,
   Patch,
   Post,
   Query,
-  Req,
   UseGuards,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -23,6 +23,7 @@ import { RegisterFcmTokenDto } from './dto/request/register-fcm-token.dto';
 import { DeleteFcmTokenDto } from './dto/request/delete-fcm-token.dto';
 import { TestNotificationDto } from './dto/request/test-notification.dto';
 import { NotificationStrategyService } from './strategies/notification-strategy.service';
+import { EntryAlertResponseDto } from './dto/response/entry-alert-response.dto';
 
 @ApiTags('알림')
 @Controller(`${API_PREFIX}/notifications`)
@@ -192,5 +193,18 @@ export class NotificationController {
       title: message.title,
       content: message.content,
     };
+  }
+
+  @Post('entry-alerts')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: '앱 진입 알림 조회 및 노출 처리',
+    description:
+      '앱 진입 시 보여줄 알림을 조회하고, 응답에 포함된 항목은 노출 완료 처리합니다.',
+  })
+  async getEntryAlerts(
+    @CurrentUser() user: { userId: number },
+  ): Promise<EntryAlertResponseDto> {
+    return this.notificationService.getEntryAlertsAndMarkShown(user.userId);
   }
 }

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -23,6 +23,7 @@ import { RecommendationNotificationScheduler } from './scheduler/recommendation-
 import { MetricsModule } from '../metrics/metrics.module';
 import { PrismaModule } from 'prisma/prisma.module';
 import { NotificationDispatchService } from './service/notification-dispatch.service';
+import { EntryAlertService } from './service/entry-alert.service';
 
 @Module({
   imports: [
@@ -52,6 +53,7 @@ import { NotificationDispatchService } from './service/notification-dispatch.ser
     NotificationCleanupScheduler,
     InterestConcertNotificationScheduler,
     RecommendationNotificationScheduler,
+    EntryAlertService,
   ],
   exports: [NotificationService],
 })

--- a/src/notification/service/entry-alert.service.ts
+++ b/src/notification/service/entry-alert.service.ts
@@ -1,0 +1,333 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConcertRequestResult, ConcertStatus } from '@prisma/client';
+import { PrismaService } from 'prisma/prisma.service';
+import { UserService } from 'src/user/user.service';
+import {
+  EntryAlertItemDto,
+  EntryAlertKind,
+  EntryAlertResponseDto,
+} from '../dto/response/entry-alert-response.dto';
+
+type InterestConcertAlertRow = {
+  id: number;
+  concertTitle: string | null;
+  concert: {
+    title: string | null;
+  };
+};
+
+type ConcertRequestAlertRow = {
+  id: number;
+  concertId: number | null;
+  concertTitle: string;
+  requestResult: ConcertRequestResult | null;
+  concert: {
+    title: string | null;
+  } | null;
+};
+
+type RegisteredInterestConcertTitleRow = {
+  concertId: number;
+  concertTitle: string | null;
+  concert: {
+    title: string | null;
+  };
+};
+
+const REQUEST_ALERT_TITLE_MAX_LENGTH = 19;
+
+@Injectable()
+export class EntryAlertService {
+  private readonly logger = new Logger(EntryAlertService.name);
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly userService: UserService,
+  ) {}
+
+  async getEntryAlertsAndMarkShown(
+    userId: number,
+  ): Promise<EntryAlertResponseDto> {
+    await this.userService.validateUser(userId);
+
+    return this.prisma.$transaction(async (tx) => {
+      const completedConcerts = await tx.userInterestConcert.findMany({
+        where: {
+          userId,
+          toastShown: false,
+          concert: {
+            status: ConcertStatus.COMPLETED,
+          },
+        },
+        select: {
+          id: true,
+          concertTitle: true,
+          concert: {
+            select: {
+              title: true,
+            },
+          },
+        },
+        orderBy: { id: 'asc' },
+      });
+
+      const canceledConcerts = await tx.userInterestConcert.findMany({
+        where: {
+          userId,
+          toastShown: false,
+          concert: {
+            status: ConcertStatus.CANCELED,
+          },
+        },
+        select: {
+          id: true,
+          concertTitle: true,
+          concert: {
+            select: {
+              title: true,
+            },
+          },
+        },
+        orderBy: { id: 'asc' },
+      });
+
+      const requests = await tx.concertRequest.findMany({
+        where: {
+          userId,
+          registrationToastShown: false,
+          requestResult: {
+            not: null,
+          },
+        },
+        select: {
+          id: true,
+          concertId: true,
+          concertTitle: true,
+          requestResult: true,
+          concert: {
+            select: {
+              title: true,
+            },
+          },
+        },
+        orderBy: { updatedAt: 'desc' },
+      });
+
+      const registeredConcertIds = requests
+        .filter((request) => {
+          return (
+            request.requestResult === ConcertRequestResult.REGISTERED &&
+            request.concertId !== null
+          );
+        })
+        .map((request) => request.concertId as number);
+
+      const registeredInterestConcerts =
+        registeredConcertIds.length > 0
+          ? await tx.userInterestConcert.findMany({
+              where: {
+                userId,
+                concertId: { in: registeredConcertIds },
+              },
+              select: {
+                concertId: true,
+                concertTitle: true,
+                concert: {
+                  select: {
+                    title: true,
+                  },
+                },
+              },
+            })
+          : [];
+
+      const registeredTitleByConcertId = this.buildRegisteredTitleMap(
+        registeredInterestConcerts,
+      );
+
+      const items: EntryAlertItemDto[] = [];
+      const consumedInterestConcertIds: number[] = [];
+      const consumedRequestIds: number[] = [];
+
+      const completedItem = this.buildAutoRemovedItem(
+        EntryAlertKind.AUTO_REMOVED_COMPLETED,
+        completedConcerts,
+      );
+
+      if (completedItem) {
+        items.push(completedItem);
+        consumedInterestConcertIds.push(
+          ...completedConcerts.map((item) => item.id),
+        );
+      }
+
+      const canceledItem = this.buildAutoRemovedItem(
+        EntryAlertKind.AUTO_REMOVED_CANCELED,
+        canceledConcerts,
+      );
+      if (canceledItem) {
+        items.push(canceledItem);
+        consumedInterestConcertIds.push(
+          ...canceledConcerts.map((item) => item.id),
+        );
+      }
+
+      for (const request of requests) {
+        const item = this.buildRequestItem(request, registeredTitleByConcertId);
+        if (!item) continue;
+
+        items.push(item);
+        consumedRequestIds.push(request.id);
+      }
+
+      if (consumedInterestConcertIds.length > 0) {
+        await tx.userInterestConcert.updateMany({
+          where: {
+            id: { in: consumedInterestConcertIds },
+          },
+          data: {
+            toastShown: true,
+          },
+        });
+      }
+
+      if (consumedRequestIds.length > 0) {
+        await tx.concertRequest.updateMany({
+          where: {
+            id: { in: consumedRequestIds },
+          },
+          data: {
+            registrationToastShown: true,
+          },
+        });
+      }
+
+      return new EntryAlertResponseDto(items);
+    });
+  }
+
+  private buildAutoRemovedItem(
+    kind:
+      | EntryAlertKind.AUTO_REMOVED_COMPLETED
+      | EntryAlertKind.AUTO_REMOVED_CANCELED,
+    concerts: InterestConcertAlertRow[],
+  ): EntryAlertItemDto | null {
+    if (concerts.length === 0) return null;
+
+    const count = concerts.length;
+    const representativeTitle = this.getInterestConcertTitle(concerts[0]);
+
+    if (kind === EntryAlertKind.AUTO_REMOVED_COMPLETED) {
+      return {
+        kind,
+        title: `자동 정리된 공연 ${count}`,
+        content:
+          count === 1
+            ? `${this.withSubjectParticle(representativeTitle)} 자동 정리 됐어요`
+            : `${representativeTitle} 외 ${count - 1}건이 자동 정리 됐어요`,
+      };
+    }
+
+    return {
+      kind,
+      title: `취소된 공연 ${count}`,
+      content:
+        count === 1
+          ? `${this.withSubjectParticle(representativeTitle)} 취소되어 자동 정리 됐어요`
+          : `${representativeTitle} 외 ${count - 1}건이 취소되어 자동 정리 됐어요`,
+    };
+  }
+
+  private buildRequestItem(
+    request: ConcertRequestAlertRow,
+    registeredTitleByConcertId: Map<number, string>,
+  ): EntryAlertItemDto | null {
+    switch (request.requestResult) {
+      case ConcertRequestResult.REGISTERED:
+        if (!request.concertId) {
+          this.logger.warn(
+            `REGISTERED concert request has no concertId, requestId=${request.id}`,
+          );
+          return null;
+        }
+
+        if (!registeredTitleByConcertId.has(request.concertId)) {
+          this.logger.warn(
+            `REGISTERED concert request has no userInterestConcert row. requestId=${request.id}, concertId=${request.concertId}`,
+          );
+        }
+
+        return {
+          kind: EntryAlertKind.REQUEST_REGISTERED,
+          title: this.truncateRequestAlertTitle(
+            registeredTitleByConcertId.get(request.concertId) ??
+              request.concert?.title ??
+              request.concertTitle,
+          ),
+          content: `나의 관심 콘서트에 추가됐어요`,
+          concertId: request.concertId,
+        };
+
+      case ConcertRequestResult.UNSUPPORTED_GENRE:
+        return {
+          kind: EntryAlertKind.REQUEST_FAILED,
+          title: this.truncateRequestAlertTitle(request.concertTitle),
+          content: '장르가 없어 관심 콘서트에 추가되지 않았어요',
+        };
+
+      case ConcertRequestResult.PAST_CONCERT:
+        return {
+          kind: EntryAlertKind.REQUEST_FAILED,
+          title: this.truncateRequestAlertTitle(request.concertTitle),
+          content: '지난 공연으로 관심 콘서트에 추가되지 않았어요',
+        };
+
+      case ConcertRequestResult.INSUFFICIENT_INFORMATION:
+        return {
+          kind: EntryAlertKind.REQUEST_FAILED,
+          title: this.truncateRequestAlertTitle(request.concertTitle),
+          content: '정확한 정보가 부족하여 추가되지 않았어요',
+        };
+
+      default:
+        return null;
+    }
+  }
+
+  private getInterestConcertTitle(item: InterestConcertAlertRow): string {
+    return item.concertTitle ?? item.concert.title ?? '공연';
+  }
+
+  private buildRegisteredTitleMap(
+    interests: RegisteredInterestConcertTitleRow[],
+  ): Map<number, string> {
+    return new Map(
+      interests.map((interest) => [
+        interest.concertId,
+        interest.concertTitle ?? interest.concert.title ?? '공연',
+      ]),
+    );
+  }
+
+  private truncateRequestAlertTitle(title: string): string {
+    const trimmedTitle = title.trim();
+
+    if (trimmedTitle.length <= REQUEST_ALERT_TITLE_MAX_LENGTH) {
+      return trimmedTitle;
+    }
+
+    return `${trimmedTitle.slice(0, REQUEST_ALERT_TITLE_MAX_LENGTH)}...`;
+  }
+
+  private withSubjectParticle(text: string): string {
+    const trimmed = text.trim();
+    const lastChar = trimmed.charCodeAt(trimmed.length - 1);
+
+    if (lastChar < 0xac00 || lastChar > 0xd7a3) {
+      return `${trimmed}이`;
+    }
+
+    const hasBatchim = (lastChar - 0xac00) % 28 !== 0;
+    return `${trimmed}${hasBatchim ? '이' : '가'}`;
+  }
+}

--- a/src/notification/service/entry-alert.service.ts
+++ b/src/notification/service/entry-alert.service.ts
@@ -13,6 +13,7 @@ type InterestConcertAlertRow = {
   concertTitle: string | null;
   concert: {
     title: string | null;
+    status: ConcertStatus;
   };
 };
 
@@ -51,12 +52,14 @@ export class EntryAlertService {
     await this.userService.validateUser(userId);
 
     return this.prisma.$transaction(async (tx) => {
-      const completedConcerts = await tx.userInterestConcert.findMany({
+      const interestConcerts = await tx.userInterestConcert.findMany({
         where: {
           userId,
           toastShown: false,
           concert: {
-            status: ConcertStatus.COMPLETED,
+            status: {
+              in: [ConcertStatus.COMPLETED, ConcertStatus.CANCELED],
+            },
           },
         },
         select: {
@@ -65,31 +68,19 @@ export class EntryAlertService {
           concert: {
             select: {
               title: true,
+              status: true,
             },
           },
         },
         orderBy: { id: 'asc' },
       });
 
-      const canceledConcerts = await tx.userInterestConcert.findMany({
-        where: {
-          userId,
-          toastShown: false,
-          concert: {
-            status: ConcertStatus.CANCELED,
-          },
-        },
-        select: {
-          id: true,
-          concertTitle: true,
-          concert: {
-            select: {
-              title: true,
-            },
-          },
-        },
-        orderBy: { id: 'asc' },
-      });
+      const completedConcerts = interestConcerts.filter(
+        (item) => item.concert.status === ConcertStatus.COMPLETED,
+      );
+      const canceledConcerts = interestConcerts.filter(
+        (item) => item.concert.status === ConcertStatus.CANCELED,
+      );
 
       const requests = await tx.concertRequest.findMany({
         where: {
@@ -147,7 +138,7 @@ export class EntryAlertService {
 
       const items: EntryAlertItemDto[] = [];
       const consumedInterestConcertIds: number[] = [];
-      const consumedRequestIds: number[] = [];
+      const processedRequestIds: number[] = [];
 
       const completedItem = this.buildAutoRemovedItem(
         EntryAlertKind.AUTO_REMOVED_COMPLETED,
@@ -174,10 +165,11 @@ export class EntryAlertService {
 
       for (const request of requests) {
         const item = this.buildRequestItem(request, registeredTitleByConcertId);
+        processedRequestIds.push(request.id);
+
         if (!item) continue;
 
         items.push(item);
-        consumedRequestIds.push(request.id);
       }
 
       if (consumedInterestConcertIds.length > 0) {
@@ -191,10 +183,10 @@ export class EntryAlertService {
         });
       }
 
-      if (consumedRequestIds.length > 0) {
+      if (processedRequestIds.length > 0) {
         await tx.concertRequest.updateMany({
           where: {
-            id: { in: consumedRequestIds },
+            id: { in: processedRequestIds },
           },
           data: {
             registrationToastShown: true,
@@ -321,6 +313,9 @@ export class EntryAlertService {
 
   private withSubjectParticle(text: string): string {
     const trimmed = text.trim();
+    if (!trimmed) {
+      return '';
+    }
     const lastChar = trimmed.charCodeAt(trimmed.length - 1);
 
     if (lastChar < 0xac00 || lastChar > 0xd7a3) {

--- a/src/notification/service/notification.service.ts
+++ b/src/notification/service/notification.service.ts
@@ -14,6 +14,8 @@ import { NotificationHistoryService } from './notification-history.service';
 import { PushSenderService } from './push-sender.service';
 import { NotificationStrategyService } from '../strategies/notification-strategy.service';
 import { NotificationTargetParams } from '../strategies/notification-strategy.interface';
+import { EntryAlertResponseDto } from '../dto/response/entry-alert-response.dto';
+import { EntryAlertService } from './entry-alert.service';
 
 @Injectable()
 export class NotificationService {
@@ -23,6 +25,7 @@ export class NotificationService {
     private readonly historyService: NotificationHistoryService,
     private readonly pushSenderService: PushSenderService,
     private readonly strategyService: NotificationStrategyService,
+    private readonly entryAlertService: EntryAlertService,
   ) {}
 
   // 알림 설정 관련
@@ -89,6 +92,12 @@ export class NotificationService {
     notificationId: number,
   ): Promise<void> {
     return this.historyService.deleteNotification(userId, notificationId);
+  }
+
+  async getEntryAlertsAndMarkShown(
+    userId: number,
+  ): Promise<EntryAlertResponseDto> {
+    return this.entryAlertService.getEntryAlertsAndMarkShown(userId);
   }
 
   //푸시 전송 (비즈니스 로직 + 히스토리 저장)

--- a/src/notification/test/entry-alert.service.spec.ts
+++ b/src/notification/test/entry-alert.service.spec.ts
@@ -55,19 +55,26 @@ describe('EntryAlertService', () => {
         {
           id: 1,
           concertTitle: '완료 공연 A',
-          concert: { title: '최신 완료 공연 A' },
+          concert: {
+            title: '최신 완료 공연 A',
+            status: ConcertStatus.COMPLETED,
+          },
         },
         {
           id: 2,
           concertTitle: '완료 공연 B',
-          concert: { title: '최신 완료 공연 B' },
+          concert: {
+            title: '최신 완료 공연 B',
+            status: ConcertStatus.COMPLETED,
+          },
         },
-      ])
-      .mockResolvedValueOnce([
         {
           id: 3,
           concertTitle: '취소 공연',
-          concert: { title: '최신 취소 공연' },
+          concert: {
+            title: '최신 취소 공연',
+            status: ConcertStatus.CANCELED,
+          },
         },
       ])
       .mockResolvedValueOnce([
@@ -109,20 +116,9 @@ describe('EntryAlertService', () => {
           userId: 1,
           toastShown: false,
           concert: {
-            status: ConcertStatus.COMPLETED,
-          },
-        },
-      }),
-    );
-
-    expect(mockTx.userInterestConcert.findMany).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({
-        where: {
-          userId: 1,
-          toastShown: false,
-          concert: {
-            status: ConcertStatus.CANCELED,
+            status: {
+              in: [ConcertStatus.COMPLETED, ConcertStatus.CANCELED],
+            },
           },
         },
       }),
@@ -184,9 +180,7 @@ describe('EntryAlertService', () => {
   });
 
   it('보여줄 알림이 없으면 빈 items를 반환하고 update를 호출하지 않는다', async () => {
-    mockTx.userInterestConcert.findMany
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]);
+    mockTx.userInterestConcert.findMany.mockResolvedValueOnce([]);
 
     mockTx.concertRequest.findMany.mockResolvedValue([]);
 
@@ -201,7 +195,6 @@ describe('EntryAlertService', () => {
     const title19 = '1234567890123456789';
 
     mockTx.userInterestConcert.findMany
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
         {
@@ -241,5 +234,38 @@ describe('EntryAlertService', () => {
         registrationToastShown: true,
       },
     });
+  });
+
+  it('응답 item을 만들 수 없는 요청 결과도 노출 완료 처리한다', async () => {
+    const warnSpy = jest
+      .spyOn((service as any).logger, 'warn')
+      .mockImplementation();
+
+    mockTx.userInterestConcert.findMany.mockResolvedValueOnce([]);
+    mockTx.concertRequest.findMany.mockResolvedValue([
+      {
+        id: 10,
+        concertId: null,
+        concertTitle: 'concertId 없는 등록 요청',
+        requestResult: ConcertRequestResult.REGISTERED,
+        concert: null,
+      },
+    ]);
+
+    const result = await service.getEntryAlertsAndMarkShown(1);
+
+    expect(result.items).toEqual([]);
+    expect(mockTx.userInterestConcert.updateMany).not.toHaveBeenCalled();
+    expect(mockTx.concertRequest.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: [10] },
+      },
+      data: {
+        registrationToastShown: true,
+      },
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      'REGISTERED concert request has no concertId, requestId=10',
+    );
   });
 });

--- a/src/notification/test/entry-alert.service.spec.ts
+++ b/src/notification/test/entry-alert.service.spec.ts
@@ -1,0 +1,245 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConcertRequestResult, ConcertStatus } from '@prisma/client';
+import { PrismaService } from 'prisma/prisma.service';
+import { UserService } from 'src/user/user.service';
+import { EntryAlertKind } from '../dto/response/entry-alert-response.dto';
+import { EntryAlertService } from '../service/entry-alert.service';
+
+describe('EntryAlertService', () => {
+  let service: EntryAlertService;
+  let mockTx: any;
+  let mockPrisma: any;
+  let mockUserService: {
+    validateUser: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    mockTx = {
+      userInterestConcert: {
+        findMany: jest.fn(),
+        updateMany: jest.fn(),
+      },
+      concertRequest: {
+        findMany: jest.fn(),
+        updateMany: jest.fn(),
+      },
+    };
+
+    mockPrisma = {
+      $transaction: jest.fn((callback: (tx: any) => Promise<unknown>) =>
+        callback(mockTx),
+      ),
+    };
+
+    mockUserService = {
+      validateUser: jest.fn().mockResolvedValue({ id: 1 }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EntryAlertService,
+        { provide: PrismaService, useValue: mockPrisma },
+        { provide: UserService, useValue: mockUserService },
+      ],
+    }).compile();
+
+    service = module.get<EntryAlertService>(EntryAlertService);
+  });
+
+  it('앱 진입 알림을 만들고 응답된 데이터만 노출 완료 처리한다', async () => {
+    const registeredTitle = '12345678901234567890등록공연';
+    const failedTitle = '12345678901234567890실패공연';
+
+    mockTx.userInterestConcert.findMany
+      .mockResolvedValueOnce([
+        {
+          id: 1,
+          concertTitle: '완료 공연 A',
+          concert: { title: '최신 완료 공연 A' },
+        },
+        {
+          id: 2,
+          concertTitle: '완료 공연 B',
+          concert: { title: '최신 완료 공연 B' },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 3,
+          concertTitle: '취소 공연',
+          concert: { title: '최신 취소 공연' },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          concertId: 55,
+          concertTitle: registeredTitle,
+          concert: { title: '최신 등록 공연' },
+        },
+      ]);
+
+    mockTx.concertRequest.findMany.mockResolvedValue([
+      {
+        id: 10,
+        concertId: 55,
+        concertTitle: '요청 등록 공연',
+        requestResult: ConcertRequestResult.REGISTERED,
+        concert: { title: '요청 등록 공연 최신 제목' },
+      },
+      {
+        id: 11,
+        concertId: null,
+        concertTitle: failedTitle,
+        requestResult: ConcertRequestResult.INSUFFICIENT_INFORMATION,
+        concert: null,
+      },
+    ]);
+
+    mockTx.userInterestConcert.updateMany.mockResolvedValue({ count: 3 });
+    mockTx.concertRequest.updateMany.mockResolvedValue({ count: 2 });
+
+    const result = await service.getEntryAlertsAndMarkShown(1);
+
+    expect(mockUserService.validateUser).toHaveBeenCalledWith(1);
+
+    expect(mockTx.userInterestConcert.findMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: {
+          userId: 1,
+          toastShown: false,
+          concert: {
+            status: ConcertStatus.COMPLETED,
+          },
+        },
+      }),
+    );
+
+    expect(mockTx.userInterestConcert.findMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: {
+          userId: 1,
+          toastShown: false,
+          concert: {
+            status: ConcertStatus.CANCELED,
+          },
+        },
+      }),
+    );
+
+    expect(mockTx.concertRequest.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          userId: 1,
+          registrationToastShown: false,
+          requestResult: {
+            not: null,
+          },
+        },
+      }),
+    );
+
+    expect(result.items).toEqual([
+      {
+        kind: EntryAlertKind.AUTO_REMOVED_COMPLETED,
+        title: '자동 정리된 공연 2',
+        content: '완료 공연 A 외 1건이 자동 정리 됐어요',
+      },
+      {
+        kind: EntryAlertKind.AUTO_REMOVED_CANCELED,
+        title: '취소된 공연 1',
+        content: '취소 공연이 취소되어 자동 정리 됐어요',
+      },
+      {
+        kind: EntryAlertKind.REQUEST_REGISTERED,
+        title: `${registeredTitle.slice(0, 19)}...`,
+        content: '나의 관심 콘서트에 추가됐어요',
+        concertId: 55,
+      },
+      {
+        kind: EntryAlertKind.REQUEST_FAILED,
+        title: `${failedTitle.slice(0, 19)}...`,
+        content: '정확한 정보가 부족하여 추가되지 않았어요',
+      },
+    ]);
+
+    expect(mockTx.userInterestConcert.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: [1, 2, 3] },
+      },
+      data: {
+        toastShown: true,
+      },
+    });
+
+    expect(mockTx.concertRequest.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: [10, 11] },
+      },
+      data: {
+        registrationToastShown: true,
+      },
+    });
+  });
+
+  it('보여줄 알림이 없으면 빈 items를 반환하고 update를 호출하지 않는다', async () => {
+    mockTx.userInterestConcert.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    mockTx.concertRequest.findMany.mockResolvedValue([]);
+
+    const result = await service.getEntryAlertsAndMarkShown(1);
+
+    expect(result.items).toEqual([]);
+    expect(mockTx.userInterestConcert.updateMany).not.toHaveBeenCalled();
+    expect(mockTx.concertRequest.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('요청 결과 제목이 19자 이하면 말줄임하지 않는다', async () => {
+    const title19 = '1234567890123456789';
+
+    mockTx.userInterestConcert.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          concertId: 55,
+          concertTitle: title19,
+          concert: { title: '최신 공연명' },
+        },
+      ]);
+
+    mockTx.concertRequest.findMany.mockResolvedValue([
+      {
+        id: 10,
+        concertId: 55,
+        concertTitle: '요청 공연명',
+        requestResult: ConcertRequestResult.REGISTERED,
+        concert: { title: '최신 공연명' },
+      },
+    ]);
+
+    const result = await service.getEntryAlertsAndMarkShown(1);
+
+    expect(result.items).toEqual([
+      {
+        kind: EntryAlertKind.REQUEST_REGISTERED,
+        title: title19,
+        content: '나의 관심 콘서트에 추가됐어요',
+        concertId: 55,
+      },
+    ]);
+
+    expect(mockTx.userInterestConcert.updateMany).not.toHaveBeenCalled();
+    expect(mockTx.concertRequest.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: { in: [10] },
+      },
+      data: {
+        registrationToastShown: true,
+      },
+    });
+  });
+});

--- a/src/notification/test/firebase.spec.ts
+++ b/src/notification/test/firebase.spec.ts
@@ -6,6 +6,7 @@ import { FcmTokenService } from '../service/fcm-token.service';
 import { NotificationHistoryService } from '../service/notification-history.service';
 import { PushSenderService } from '../service/push-sender.service';
 import { NotificationStrategyService } from '../strategies/notification-strategy.service';
+import { EntryAlertService } from '../service/entry-alert.service';
 
 describe('NotificationService (푸시 발송)', () => {
   let service: NotificationService;
@@ -24,6 +25,9 @@ describe('NotificationService (푸시 발송)', () => {
     getStrategy: jest.fn(),
     createTicketReminderStrategy: jest.fn(),
   };
+  const mockEntryAlertService = {
+    getEntryAlertsAndMarkShown: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -34,6 +38,7 @@ describe('NotificationService (푸시 발송)', () => {
         { provide: NotificationHistoryService, useValue: mockHistoryService },
         { provide: PushSenderService, useValue: mockPushSenderService },
         { provide: NotificationStrategyService, useValue: mockStrategyService },
+        { provide: EntryAlertService, useValue: mockEntryAlertService },
       ],
     }).compile();
 

--- a/src/notification/test/notification-list.spec.ts
+++ b/src/notification/test/notification-list.spec.ts
@@ -8,6 +8,7 @@ import { FcmTokenService } from '../service/fcm-token.service';
 import { NotificationHistoryService } from '../service/notification-history.service';
 import { PushSenderService } from '../service/push-sender.service';
 import { NotificationStrategyService } from '../strategies/notification-strategy.service';
+import { EntryAlertService } from '../service/entry-alert.service';
 
 describe('NotificationService - 알림 목록', () => {
   let service: NotificationService;
@@ -49,6 +50,9 @@ describe('NotificationService - 알림 목록', () => {
     getStrategy: jest.fn(),
     createTicketReminderStrategy: jest.fn(),
   };
+  const mockEntryAlertService = {
+    getEntryAlertsAndMarkShown: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -59,6 +63,7 @@ describe('NotificationService - 알림 목록', () => {
         { provide: NotificationHistoryService, useValue: mockHistoryService },
         { provide: PushSenderService, useValue: mockPushSenderService },
         { provide: NotificationStrategyService, useValue: mockStrategyService },
+        { provide: EntryAlertService, useValue: mockEntryAlertService },
       ],
     }).compile();
 

--- a/src/notification/test/notification-send.integration.spec.ts
+++ b/src/notification/test/notification-send.integration.spec.ts
@@ -7,6 +7,7 @@ import { FcmTokenService } from '../service/fcm-token.service';
 import { NotificationHistoryService } from '../service/notification-history.service';
 import { PushSenderService } from '../service/push-sender.service';
 import { NotificationStrategyService } from '../strategies/notification-strategy.service';
+import { EntryAlertService } from '../service/entry-alert.service';
 
 const mockSendEachForMulticast = jest.fn();
 
@@ -45,6 +46,9 @@ describe('Notification send integration (FCM mock)', () => {
   const mockHistoryService = {
     createNotificationHistories: jest.fn(),
   };
+  const mockEntryAlertService = {
+    getEntryAlertsAndMarkShown: jest.fn(),
+  };
 
   beforeEach(async () => {
     mockSendEachForMulticast.mockResolvedValue({
@@ -61,6 +65,7 @@ describe('Notification send integration (FCM mock)', () => {
         { provide: NotificationHistoryService, useValue: mockHistoryService },
         PushSenderService,
         { provide: NotificationStrategyService, useValue: mockStrategyService },
+        { provide: EntryAlertService, useValue: mockEntryAlertService },
         {
           provide: 'PROM_METRIC_FCM_NOTIFICATION_SENT_TOTAL',
           useValue: { inc: jest.fn() },

--- a/src/notification/test/notification-service.spec.ts
+++ b/src/notification/test/notification-service.spec.ts
@@ -9,6 +9,7 @@ import { FcmTokenService } from '../service/fcm-token.service';
 import { NotificationHistoryService } from '../service/notification-history.service';
 import { PushSenderService } from '../service/push-sender.service';
 import { NotificationStrategyService } from '../strategies/notification-strategy.service';
+import { EntryAlertService } from '../service/entry-alert.service';
 
 describe('NotificationService', () => {
   let service: NotificationService;
@@ -49,6 +50,9 @@ describe('NotificationService', () => {
     getStrategy: jest.fn().mockReturnValue(mockStrategy),
     createTicketReminderStrategy: jest.fn().mockReturnValue(mockStrategy),
   };
+  const mockEntryAlertService = {
+    getEntryAlertsAndMarkShown: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -60,6 +64,7 @@ describe('NotificationService', () => {
         { provide: NotificationHistoryService, useValue: mockHistoryService },
         { provide: PushSenderService, useValue: mockPushSenderService },
         { provide: NotificationStrategyService, useValue: mockStrategyService },
+        { provide: EntryAlertService, useValue: mockEntryAlertService },
       ],
     }).compile();
 


### PR DESCRIPTION
## #️⃣ Issue Number
> Closed #326 

## 📝 요약(Summary)
> 앱 진입시 보여줄 알림을 조회하고, 응답에 포함된 항목을 노출 완료 처리하는 API 구현 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 완료/취소된 관심 공연은 user_interest_concerts.toastshown = false 기준으로 조회, 응답 후 true로 변경
- 요청 공연 결과는 concert_requests.registrationToastShown=false + requestResult IS NOT NULL 기준으로 조회, 응답 후 true 변경
- 공백 포함 19자 초과 시 '...' 말줄임으로 처리
- 콘서트 제목은 완료/취소된 관심공연 + 요청 공연 결과 성공일때는 user_interest_concerts.concert_title
- 실패했을때는 concert_requests.concert_title

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
