### PR TITLE
✨ feat: 홈워커 claim api 롱풀링 전환 

### DIFF
--- a/src/extraction/extraction-events.service.spec.ts
+++ b/src/extraction/extraction-events.service.spec.ts
@@ -62,4 +62,39 @@ describe('ExtractionEventsService', () => {
     await p;
     jest.useRealTimers();
   });
+
+  describe('prepareWaitCreated (subscribe-then-act)', () => {
+    it('구독 후에 발생한 생성 이벤트로 wait 가 즉시 resolve 된다', async () => {
+      const waiter = service.prepareWaitCreated();
+      const p = waiter.wait(10_000);
+      service.notifyCreated();
+      await expect(p).resolves.toBeUndefined();
+      waiter.cleanup();
+    });
+
+    it('wait 시작 전(구독 후)에 이미 발생한 이벤트도 놓치지 않는다', async () => {
+      // 구독(prepare) ~ wait 사이에 emit 이 끼어든 상황: 유실 없이 즉시 resolve 돼야 함
+      const waiter = service.prepareWaitCreated();
+      service.notifyCreated();
+      await expect(waiter.wait(10_000)).resolves.toBeUndefined();
+      waiter.cleanup();
+    });
+
+    it('이벤트 없으면 timeout 으로 resolve 된다', async () => {
+      jest.useFakeTimers();
+      const waiter = service.prepareWaitCreated();
+      const p = waiter.wait(5_000);
+      jest.advanceTimersByTime(5_000);
+      await expect(p).resolves.toBeUndefined();
+      waiter.cleanup();
+      jest.useRealTimers();
+    });
+
+    it('cleanup 후에는 리스너가 남지 않는다', () => {
+      const waiter = service.prepareWaitCreated();
+      expect(emitter.listenerCount('extraction-job.created')).toBe(1);
+      waiter.cleanup();
+      expect(emitter.listenerCount('extraction-job.created')).toBe(0);
+    });
+  });
 });

--- a/src/extraction/extraction-events.service.ts
+++ b/src/extraction/extraction-events.service.ts
@@ -30,14 +30,34 @@ export class ExtractionEventsService {
   }
 
   /**
-   * 새 잡 생성까지 대기(claim 롱폴링용). 전역 이벤트라 대기 중인 워커 전원이 깨어나고,
+   * claim 롱폴링용 생성 이벤트 대기자(subscribe-then-act).
+   * 구독을 claim 시도보다 먼저 걸게 해서 claim(null) ~ 구독 사이의
+   * 이벤트 유실 틈을 없앤다. 전역 이벤트라 대기 중인 워커 전원이 깨어나고,
    * 실제 잡 획득은 claim의 FOR UPDATE SKIP LOCKED가 결정한다.
    */
-  async waitForCreated(
-    timeoutMs: number,
-    checkAlreadyCreated?: () => Promise<boolean>,
-  ): Promise<void> {
-    return this.waitFor(CREATED_KEY, timeoutMs, checkAlreadyCreated);
+  prepareWaitCreated() {
+    let resolveEvent!: () => void;
+    const eventPromise = new Promise<void>((resolve) => {
+      resolveEvent = resolve;
+    });
+    const onEvent = () => resolveEvent();
+    this.emitter.once(CREATED_KEY, onEvent);
+
+    return {
+      /** 생성 이벤트 또는 timeout 중 먼저 오는 쪽까지 대기 */
+      wait: async (timeoutMs: number) => {
+        let timer: NodeJS.Timeout | undefined;
+        const timeoutPromise = new Promise<void>((resolve) => {
+          timer = setTimeout(resolve, timeoutMs);
+        });
+        await Promise.race([eventPromise, timeoutPromise]);
+        clearTimeout(timer);
+      },
+      /** 리스너 해제(이벤트 수신 후 once 로 이미 제거됐으면 no-op) */
+      cleanup: () => {
+        this.emitter.off(CREATED_KEY, onEvent);
+      },
+    };
   }
 
   /** 생성 대기 중인 워커 깨우기 */

--- a/src/extraction/extraction-events.service.ts
+++ b/src/extraction/extraction-events.service.ts
@@ -1,54 +1,83 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 
+const CREATED_KEY = 'extraction-job.created';
+
 @Injectable()
 export class ExtractionEventsService {
   private readonly logger = new Logger(ExtractionEventsService.name);
 
   constructor(private readonly emitter: EventEmitter2) {}
 
-  private key(jobId: string) {
+  private doneKey(jobId: string) {
     return `extraction-job.done.${jobId}`;
   }
 
   /**
    * 잡 완료까지 대기. timeout 안에 done 이벤트 없으면 그냥 resolve.
-   *
-   * 리스너 등록 전에 notifyDone이 먼저 발생하면 이벤트가 유실되어
-   * timeoutMs를 꽉 채우는 레이스가 있다. 리스너를 건 직후 checkAlreadyDone으로
-   * DB 상태를 재확인해 이미 종결이면 즉시 해제한다(subscribe-then-recheck).
    */
   async waitForDone(
     jobId: string,
     timeoutMs: number,
     checkAlreadyDone?: () => Promise<boolean>,
   ): Promise<void> {
+    return this.waitFor(this.doneKey(jobId), timeoutMs, checkAlreadyDone);
+  }
+
+  /** 완료 대기 중인 요청 깨우기 */
+  notifyDone(jobId: string) {
+    this.emitter.emit(this.doneKey(jobId));
+  }
+
+  /**
+   * 새 잡 생성까지 대기(claim 롱폴링용). 전역 이벤트라 대기 중인 워커 전원이 깨어나고,
+   * 실제 잡 획득은 claim의 FOR UPDATE SKIP LOCKED가 결정한다.
+   */
+  async waitForCreated(
+    timeoutMs: number,
+    checkAlreadyCreated?: () => Promise<boolean>,
+  ): Promise<void> {
+    return this.waitFor(CREATED_KEY, timeoutMs, checkAlreadyCreated);
+  }
+
+  /** 생성 대기 중인 워커 깨우기 */
+  notifyCreated() {
+    this.emitter.emit(CREATED_KEY);
+  }
+
+  /**
+   * key 이벤트까지 대기. timeout 안에 이벤트 없으면 그냥 resolve
+   *
+   * 리스너 등록 전에 emit이 먼저 발생하면 이벤트가 유실되어
+   * timeoutMs를 꽉채우는 레이스가 있다. 리스너를 건 직후 recheck로
+   * 실제 상태를 재확인해 이미 충족이면 즉시 해제한다(subscribe-then-recheck)
+   */
+  private async waitFor(
+    key: string,
+    timeoutMs: number,
+    recheck?: () => Promise<boolean>,
+  ): Promise<void> {
     return new Promise<void>((resolve) => {
-      const onDone = () => {
+      const onEvent = () => {
         clearTimeout(timer);
-        this.emitter.off(this.key(jobId), onDone);
+        this.emitter.off(key, onEvent);
         resolve();
       };
-      const timer = setTimeout(onDone, timeoutMs);
+      const timer = setTimeout(onEvent, timeoutMs);
 
-      this.emitter.once(this.key(jobId), onDone);
+      this.emitter.once(key, onEvent);
 
-      if (!checkAlreadyDone) return;
-      checkAlreadyDone()
-        .then((done) => {
-          if (done) onDone();
+      if (!recheck) return;
+      recheck()
+        .then((satisfied) => {
+          if (satisfied) onEvent();
         })
         .catch((err) => {
           // 재확인 실패는 치명적이지 않음: 이벤트/타임아웃 대기로 폴백
           this.logger.debug(
-            `waitForDone recheck failed for ${jobId}, fallback to wait: ${err?.message}`,
+            `waitFor(${key}) recheck failed, fallback to wait: ${err?.message}`,
           );
         });
     });
-  }
-
-  /** 대기 중인 요청 깨우기 */
-  notifyDone(jobId: string) {
-    this.emitter.emit(this.key(jobId));
   }
 }

--- a/src/extraction/extraction-internal.controller.ts
+++ b/src/extraction/extraction-internal.controller.ts
@@ -23,7 +23,7 @@ export class ExtractionInternalController {
 
   @Get('claim')
   async claim(@Res({ passthrough: true }) res: Response) {
-    const job = await this.extractionService.claimNext();
+    const job = await this.extractionService.claimNextOrWait();
     if (!job) {
       res.status(204).send(); // 빈 큐
       return;

--- a/src/extraction/extraction.service.spec.ts
+++ b/src/extraction/extraction.service.spec.ts
@@ -37,6 +37,8 @@ describe('ExtractionService', () => {
     mockEvents = {
       waitForDone: jest.fn().mockResolvedValue(undefined),
       notifyDone: jest.fn(),
+      waitForCreated: jest.fn().mockResolvedValue(undefined),
+      notifyCreated: jest.fn(),
     };
     mockConcertIndex = {
       matchArtist: jest.fn().mockResolvedValue([]),
@@ -68,6 +70,7 @@ describe('ExtractionService', () => {
         where: { instagramUrl: baseJob.instagramUrl },
         orderBy: { createdAt: 'desc' },
       });
+      expect(mockEvents.notifyCreated).not.toHaveBeenCalled();
     });
 
     it('종결(NO_MATCH)된 잡도 재추출 없이 캐시 반환한다', async () => {
@@ -90,6 +93,7 @@ describe('ExtractionService', () => {
         data: { instagramUrl: baseJob.instagramUrl },
       });
       expect(result).toBe(baseJob);
+      expect(mockEvents.notifyCreated).toHaveBeenCalled();
     });
   });
 
@@ -320,6 +324,56 @@ describe('ExtractionService', () => {
         jobId: 'job1',
         instagramUrl: 'https://x/p/A/',
       });
+    });
+  });
+
+  describe('claimNextOrWait (롱폴링)', () => {
+    it('첫 시도에 잡 있으면 대기 없이 즉시 반환', async () => {
+      const tx = {
+        $queryRaw: jest
+          .fn()
+          .mockResolvedValue([{ id: 'job1', instagram_url: 'https://x/p/A/' }]),
+        extractionJob: { update: jest.fn().mockResolvedValue({ id: 'job1' }) },
+      };
+      mockPrisma.$transaction.mockImplementation(async (cb: any) => cb(tx));
+
+      const result = await service.claimNextOrWait();
+
+      expect(result).toEqual({ jobId: 'job1', instagramUrl: 'https://x/p/A/' });
+      expect(mockEvents.waitForCreated).not.toHaveBeenCalled();
+    });
+
+    it('빈 큐면 생성 이벤트 대기 후 재시도해서 반환', async () => {
+      // 1차 claim 빈 큐 → 대기 → 2차 claim 성공
+      const emptyTx = { $queryRaw: jest.fn().mockResolvedValue([]) };
+      const jobTx = {
+        $queryRaw: jest
+          .fn()
+          .mockResolvedValue([{ id: 'job2', instagram_url: 'https://x/p/B/' }]),
+        extractionJob: { update: jest.fn().mockResolvedValue({ id: 'job2' }) },
+      };
+      mockPrisma.$transaction
+        .mockImplementationOnce(async (cb: any) => cb(emptyTx))
+        .mockImplementationOnce(async (cb: any) => cb(jobTx));
+
+      const result = await service.claimNextOrWait();
+
+      expect(mockEvents.waitForCreated).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.any(Function),
+      );
+      expect(result).toEqual({ jobId: 'job2', instagramUrl: 'https://x/p/B/' });
+    });
+
+    it('예산 소진까지 잡 없으면 null (대기 없이 종료)', async () => {
+      mockPrisma.$transaction.mockImplementation(async (cb: any) =>
+        cb({ $queryRaw: jest.fn().mockResolvedValue([]) }),
+      );
+
+      const result = await service.claimNextOrWait(0);
+
+      expect(result).toBeNull();
+      expect(mockEvents.waitForCreated).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/extraction/extraction.service.spec.ts
+++ b/src/extraction/extraction.service.spec.ts
@@ -8,6 +8,7 @@ describe('ExtractionService', () => {
   let service: ExtractionService;
   let mockPrisma: any;
   let mockEvents: any;
+  let mockWaiter: any;
   let mockConcertIndex: any;
 
   const baseJob = {
@@ -34,10 +35,14 @@ describe('ExtractionService', () => {
       $queryRaw: jest.fn(),
       $executeRaw: jest.fn(),
     };
+    mockWaiter = {
+      wait: jest.fn().mockResolvedValue(undefined),
+      cleanup: jest.fn(),
+    };
     mockEvents = {
       waitForDone: jest.fn().mockResolvedValue(undefined),
       notifyDone: jest.fn(),
-      waitForCreated: jest.fn().mockResolvedValue(undefined),
+      prepareWaitCreated: jest.fn(() => mockWaiter),
       notifyCreated: jest.fn(),
     };
     mockConcertIndex = {
@@ -340,7 +345,9 @@ describe('ExtractionService', () => {
       const result = await service.claimNextOrWait();
 
       expect(result).toEqual({ jobId: 'job1', instagramUrl: 'https://x/p/A/' });
-      expect(mockEvents.waitForCreated).not.toHaveBeenCalled();
+      // 구독은 claim보다 먼저 걸리지만(subscribe-then-act) 대기 없이 정리돼야 함
+      expect(mockWaiter.wait).not.toHaveBeenCalled();
+      expect(mockWaiter.cleanup).toHaveBeenCalled();
     });
 
     it('빈 큐면 생성 이벤트 대기 후 재시도해서 반환', async () => {
@@ -358,22 +365,20 @@ describe('ExtractionService', () => {
 
       const result = await service.claimNextOrWait();
 
-      expect(mockEvents.waitForCreated).toHaveBeenCalledWith(
-        expect.any(Number),
-        expect.any(Function),
-      );
+      expect(mockWaiter.wait).toHaveBeenCalledWith(expect.any(Number));
       expect(result).toEqual({ jobId: 'job2', instagramUrl: 'https://x/p/B/' });
+      // 대기자(waiter)는 루프 회차마다 새로 만들고 매번 정리
+      expect(mockEvents.prepareWaitCreated).toHaveBeenCalledTimes(2);
+      expect(mockWaiter.cleanup).toHaveBeenCalledTimes(2);
     });
 
-    it('예산 소진까지 잡 없으면 null (대기 없이 종료)', async () => {
-      mockPrisma.$transaction.mockImplementation(async (cb: any) =>
-        cb({ $queryRaw: jest.fn().mockResolvedValue([]) }),
-      );
-
+    it('예산 소진까지 잡 없으면 null (구독·claim 없이 종료)', async () => {
       const result = await service.claimNextOrWait(0);
 
       expect(result).toBeNull();
-      expect(mockEvents.waitForCreated).not.toHaveBeenCalled();
+      // 예산 체크가 루프 맨 앞이라 구독도 claim도 시도하지 않음
+      expect(mockEvents.prepareWaitCreated).not.toHaveBeenCalled();
+      expect(mockPrisma.$transaction).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/extraction/extraction.service.ts
+++ b/src/extraction/extraction.service.ts
@@ -91,8 +91,8 @@ export class ExtractionService {
   /**
    * 홈워커 claim 롱폴링 진입점.
    * 잡 있으면 즉시, 없으면 생성 이벤트를 기다렸다 재시도. 예산 소진 시 null
-   * claim(null) 직후 ~ 리스너 등록 사이의 생성 이벤트 유실은
-   * waitForCreated의 recheck(PENDING 존재 재확인)로 방어
+   * 구독을 claim 시도보다 먼저 걸어(subscribe-then-act)
+   * claim(null) ~ 구독 사이의 생성 이벤트 유실 틈을 없앤다.
    */
   async claimNextOrWait(
     timeoutMs = this.CLAIM_HOLD_MS,
@@ -100,19 +100,18 @@ export class ExtractionService {
     const deadline = Date.now() + timeoutMs;
 
     for (;;) {
-      const job = await this.claimNext();
-      if (job) return job;
-
       const remaining = deadline - Date.now();
       if (remaining <= 0) return null;
 
-      await this.events.waitForCreated(remaining, async () => {
-        const pending = await this.prisma.extractionJob.findFirst({
-          where: { status: 'PENDING' },
-          select: { id: true },
-        });
-        return pending !== null;
-      });
+      const waiter = this.events.prepareWaitCreated();
+      try {
+        const job = await this.claimNext();
+        if (job) return job;
+
+        await waiter.wait(remaining);
+      } finally {
+        waiter.cleanup();
+      }
     }
   }
 

--- a/src/extraction/extraction.service.ts
+++ b/src/extraction/extraction.service.ts
@@ -21,6 +21,7 @@ type ClientResult = 'MATCHED' | 'NO_MATCH';
 export class ExtractionService {
   private readonly logger = new Logger(ExtractionService.name);
   private readonly WAIT_MS = 30_000;
+  private readonly CLAIM_HOLD_MS = 25_000;
 
   constructor(
     private readonly prisma: PrismaService,
@@ -41,7 +42,12 @@ export class ExtractionService {
     });
     if (existing) return existing;
 
-    return this.prisma.extractionJob.create({ data: { instagramUrl } });
+    const created = await this.prisma.extractionJob.create({
+      data: { instagramUrl },
+    });
+    // 재사용 잡은 이미 큐에 있어 claim 첫 시도에 잡히므로 신규 생성만 알림
+    this.events.notifyCreated();
+    return created;
   }
 
   async findById(jobId: string): Promise<ExtractionJob> {
@@ -80,6 +86,34 @@ export class ExtractionService {
       });
       return { jobId: id, instagramUrl: instagram_url };
     });
+  }
+
+  /**
+   * 홈워커 claim 롱폴링 진입점.
+   * 잡 있으면 즉시, 없으면 생성 이벤트를 기다렸다 재시도. 예산 소진 시 null
+   * claim(null) 직후 ~ 리스너 등록 사이의 생성 이벤트 유실은
+   * waitForCreated의 recheck(PENDING 존재 재확인)로 방어
+   */
+  async claimNextOrWait(
+    timeoutMs = this.CLAIM_HOLD_MS,
+  ): Promise<{ jobId: string; instagramUrl: string } | null> {
+    const deadline = Date.now() + timeoutMs;
+
+    for (;;) {
+      const job = await this.claimNext();
+      if (job) return job;
+
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) return null;
+
+      await this.events.waitForCreated(remaining, async () => {
+        const pending = await this.prisma.extractionJob.findFirst({
+          where: { status: 'PENDING' },
+          select: { id: true },
+        });
+        return pending !== null;
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## #️⃣ Issue Number
> Closed #328 

## 📝 요약(Summary)
> claim api의 지연을 최대한 줄이고자 롱풀링 설계 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 이벤트 유실 레이스: claim 직후 ~ 리스너 등록 사이에 생정된 잡의 이벤트 유실(리스너 등록 직후 recheck로 방어)
- 25초동안 api 홀딩 

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
