### PR TITLE
✨feat: 알림 목록 테스트 서비스 및 api 구현

### DIFF
--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -24,6 +24,10 @@ import { DeleteFcmTokenDto } from './dto/request/delete-fcm-token.dto';
 import { TestNotificationDto } from './dto/request/test-notification.dto';
 import { NotificationStrategyService } from './strategies/notification-strategy.service';
 import { EntryAlertResponseDto } from './dto/response/entry-alert-response.dto';
+import {
+  SeedEntryAlertDto,
+  SeedEntryAlertKind,
+} from './dto/request/seed-entry-alert.dto';
 
 @ApiTags('알림')
 @Controller(`${API_PREFIX}/notifications`)
@@ -206,5 +210,27 @@ export class NotificationController {
     @CurrentUser() user: { userId: number },
   ): Promise<EntryAlertResponseDto> {
     return this.notificationService.getEntryAlertsAndMarkShown(user.userId);
+  }
+
+  @Post('test/entry-alerts/seed')
+  @HttpCode(200)
+  @ApiOperation({
+    summary: '[테스트] 앱 진입 알림 더미 시드',
+    description:
+      'entry-alerts 화면 확인용 더미 데이터 생성. ',
+  })
+  async seedEntryAlerts(
+    @CurrentUser() user: { userId: number },
+    @Body() dto: SeedEntryAlertDto,
+  ): Promise<{
+    users: number;
+    concertRequests: number;
+    interestConcerts: number;
+  }> {
+    return this.notificationService.seedDummyEntryAlerts({
+      callerUserId: user.userId,
+      sendToAll: dto.sendToAll ?? false,
+      kinds: dto.kinds ?? Object.values(SeedEntryAlertKind),
+    });
   }
 }

--- a/src/notification/service/entry-alert.service.ts
+++ b/src/notification/service/entry-alert.service.ts
@@ -281,7 +281,7 @@ export class EntryAlertService {
         requestRows.push({
           userId: user.id,
           concertId: null,
-          concertTitle: 'The Weeknd: After Hours Til Dawn Tour in Seoul',
+          concertTitle: '더 워닝 내한 공연 (The Warning Live) [서울]',
           requestResult: ConcertRequestResult.INSUFFICIENT_INFORMATION,
           registrationToastShown: false,
           requestContent: DUMMY_ENTRY_ALERT_MARKER,

--- a/src/notification/service/entry-alert.service.ts
+++ b/src/notification/service/entry-alert.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ConcertRequestResult, ConcertStatus } from '@prisma/client';
+import { ConcertRequestResult, ConcertStatus, Prisma } from '@prisma/client';
 import { PrismaService } from 'prisma/prisma.service';
 import { UserService } from 'src/user/user.service';
 import {
@@ -7,6 +7,7 @@ import {
   EntryAlertKind,
   EntryAlertResponseDto,
 } from '../dto/response/entry-alert-response.dto';
+import { SeedEntryAlertKind } from '../dto/request/seed-entry-alert.dto';
 
 type InterestConcertAlertRow = {
   id: number;
@@ -36,6 +37,13 @@ type RegisteredInterestConcertTitleRow = {
 };
 
 const REQUEST_ALERT_TITLE_MAX_LENGTH = 19;
+
+// 테스트 시드가 만든 더미 concert_requests 식별용(재시드 시 정리 대상)
+const DUMMY_ENTRY_ALERT_MARKER = '__DUMMY_ENTRY_ALERT__';
+// REGISTERED 더미가 참조할 고정 콘서트 ID
+const REGISTERED_CONCERT_ID = 1936;
+// 자동정리(완료/취소) 상태별 시드 개수
+const AUTO_REMOVED_SEED_COUNT = 2;
 
 @Injectable()
 export class EntryAlertService {
@@ -196,6 +204,145 @@ export class EntryAlertService {
 
       return new EntryAlertResponseDto(items);
     });
+  }
+
+  /** [테스트용] entry-alerts 화면 확인용 더미 시드(소비형이라 반복 확인 시 재호출) */
+  async seedDummyEntryAlerts(params: {
+    callerUserId: number;
+    sendToAll: boolean;
+    kinds: SeedEntryAlertKind[];
+  }): Promise<{
+    users: number;
+    concertRequests: number;
+    interestConcerts: number;
+  }> {
+    const { callerUserId, sendToAll, kinds } = params;
+    if (kinds.length === 0) {
+      return { users: 0, concertRequests: 0, interestConcerts: 0 };
+    }
+
+    const kindSet = new Set(kinds);
+    const users = await this.prisma.user.findMany({
+      where: {
+        deletedAt: null,
+        ...(sendToAll ? {} : { id: callerUserId }),
+      },
+      select: { id: true, nickname: true },
+    });
+    if (users.length === 0) {
+      return { users: 0, concertRequests: 0, interestConcerts: 0 };
+    }
+
+    // REGISTERED는 고정 콘서트 1건, 자동정리는 상태별 2건씩 참조
+    const registeredConcert = kindSet.has(SeedEntryAlertKind.REGISTERED)
+      ? await this.prisma.concert.findUnique({
+          where: { id: REGISTERED_CONCERT_ID },
+          select: { id: true, title: true },
+        })
+      : null;
+    const completedConcerts = kindSet.has(
+      SeedEntryAlertKind.AUTO_REMOVED_COMPLETED,
+    )
+      ? await this.prisma.concert.findMany({
+          where: { status: ConcertStatus.COMPLETED },
+          select: { id: true, title: true },
+          orderBy: { id: 'asc' },
+          take: AUTO_REMOVED_SEED_COUNT,
+        })
+      : [];
+    const canceledConcerts = kindSet.has(
+      SeedEntryAlertKind.AUTO_REMOVED_CANCELED,
+    )
+      ? await this.prisma.concert.findMany({
+          where: { status: ConcertStatus.CANCELED },
+          select: { id: true, title: true },
+          orderBy: { id: 'asc' },
+          take: AUTO_REMOVED_SEED_COUNT,
+        })
+      : [];
+
+    const requestRows: Prisma.ConcertRequestCreateManyInput[] = [];
+    const interestRows: Prisma.UserInterestConcertCreateManyInput[] = [];
+
+    for (const user of users) {
+      if (registeredConcert) {
+        requestRows.push({
+          userId: user.id,
+          concertId: registeredConcert.id,
+          concertTitle: registeredConcert.title ?? '테스트 콘서트',
+          requestResult: ConcertRequestResult.REGISTERED,
+          registrationToastShown: false,
+          requestContent: DUMMY_ENTRY_ALERT_MARKER,
+        });
+      }
+
+      if (kindSet.has(SeedEntryAlertKind.FAILED)) {
+        // 더미라 실패 사유는 1종으로 통일
+        requestRows.push({
+          userId: user.id,
+          concertId: null,
+          concertTitle: 'The Weeknd: After Hours Til Dawn Tour in Seoul',
+          requestResult: ConcertRequestResult.INSUFFICIENT_INFORMATION,
+          registrationToastShown: false,
+          requestContent: DUMMY_ENTRY_ALERT_MARKER,
+        });
+      }
+
+      for (const concert of [...completedConcerts, ...canceledConcerts]) {
+        interestRows.push({
+          userId: user.id,
+          concertId: concert.id,
+          concertTitle: concert.title,
+          userNickname: user.nickname,
+          toastShown: false,
+        });
+      }
+    }
+
+    let concertRequests = 0;
+    let interestConcerts = 0;
+    const userIds = users.map((u) => u.id);
+
+    await this.prisma.$transaction(async (tx) => {
+      // 재시드 누적 방지: 이전 더미만 정리 후 재생성
+      await tx.concertRequest.deleteMany({
+        where: {
+          userId: { in: userIds },
+          requestContent: DUMMY_ENTRY_ALERT_MARKER,
+        },
+      });
+      if (requestRows.length > 0) {
+        const created = await tx.concertRequest.createMany({
+          data: requestRows,
+        });
+        concertRequests = created.count;
+      }
+
+      if (interestRows.length > 0) {
+        // 중복은 스킵하고 toastShown만 false로 초기화(재사용)
+        await tx.userInterestConcert.createMany({
+          data: interestRows,
+          skipDuplicates: true,
+        });
+        const autoRemovedConcertIds = [
+          ...new Set(interestRows.map((row) => row.concertId)),
+        ];
+        const { count } = await tx.userInterestConcert.updateMany({
+          where: {
+            userId: { in: userIds },
+            concertId: { in: autoRemovedConcertIds },
+          },
+          data: { toastShown: false },
+        });
+        interestConcerts = count;
+      }
+    });
+
+    this.logger.log(
+      `seeded entry-alerts: users=${users.length}, concertRequests=${concertRequests}, interestConcerts=${interestConcerts}`,
+    );
+
+    return { users: users.length, concertRequests, interestConcerts };
   }
 
   private buildAutoRemovedItem(

--- a/src/notification/service/notification.service.ts
+++ b/src/notification/service/notification.service.ts
@@ -16,6 +16,7 @@ import { NotificationStrategyService } from '../strategies/notification-strategy
 import { NotificationTargetParams } from '../strategies/notification-strategy.interface';
 import { EntryAlertResponseDto } from '../dto/response/entry-alert-response.dto';
 import { EntryAlertService } from './entry-alert.service';
+import { SeedEntryAlertKind } from '../dto/request/seed-entry-alert.dto';
 
 @Injectable()
 export class NotificationService {
@@ -98,6 +99,18 @@ export class NotificationService {
     userId: number,
   ): Promise<EntryAlertResponseDto> {
     return this.entryAlertService.getEntryAlertsAndMarkShown(userId);
+  }
+
+  async seedDummyEntryAlerts(params: {
+    callerUserId: number;
+    sendToAll: boolean;
+    kinds: SeedEntryAlertKind[];
+  }): Promise<{
+    users: number;
+    concertRequests: number;
+    interestConcerts: number;
+  }> {
+    return this.entryAlertService.seedDummyEntryAlerts(params);
   }
 
   //푸시 전송 (비즈니스 로직 + 히스토리 저장)


### PR DESCRIPTION
## #️⃣ Issue Number
> Closed #332 

## 📝 요약(Summary)
> 알림 목록 테스트 서비스 및 api 구현 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 전체 유저 대상으로 테스트 시드 API 구현
- 자동정리 완료/및 취소는 콘서트에서  id 낮은 순으로 각각 2개씩 갖고와서 관심콘서트에 넣기(추후 삭제 예정)
- 요청 주가 완료는 콘서트에서 weeknd공연 추가  + 실패는 더 워닝 내한 공연으로(타입은 INSUFFICIENT INFORMATION으로 fix)
- API를 호출할때마다 데이터가 안쌓이도록 관심콘서트 테이블은 toast_shown만 false로 바꾸기 + 요청테이블에는 request내용에 _DUMMY를 붙여 삭제 후 insert하는 방식으로 구현
- 해당 로직들은 별도의 메서드로 만들어 기존 API 관련 로직과 충돌 x

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
